### PR TITLE
[FAQ] Clarify that framework limitation is from Apple not CP

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -5,9 +5,9 @@ permalink: /faq/
 ---
 ## FAQ
 
-#### Cocoapods won't let me install SnapKit into my iOS 7.0 project?
+#### CocoaPods won't let me install SnapKit into my iOS 7.0 project?
 
-SnapKit doesn't use any iOS 8.0 specific APIs but because Cocoapods does not support integrating Swift code without dynamic frameworks it cannot be integrated via Cocoapods for iOS 7.0 deployments. You should instead embed the source code directly into your application.
+SnapKit doesn't use any iOS 8.0 specific APIs, but since Xcode does not support integrating Swift code without dynamic frameworks it cannot be integrated via a framework for iOS 7.0 deployments. You should instead embed the source code directly into your application.
 
 #### Do you have any examples?
 


### PR DESCRIPTION
- Spell CocoaPods correctly.
- Clarify that framework limitation is from Apple not CocoaPods.