### PR TITLE
Support for UILayoutSupport on iOS 9

### DIFF
--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -241,9 +241,14 @@ internal class ConcreteConstraint: Constraint {
             let layoutConstant: CGFloat = layoutToAttribute.snp_constantForValue(self.constant)
             
             // get layout to
-            var layoutTo: View? = self.toItem.view
+            var layoutTo: AnyObject? = self.toItem.view
             if layoutTo == nil && layoutToAttribute != .Width && layoutToAttribute != .Height {
-                layoutTo = installOnView
+                #if os(iOS)
+                layoutTo = self.toItem.layoutSupport
+                #endif
+                if layoutTo == nil {
+                    layoutTo = installOnView
+                }
             }
             
             // create layout constraint


### PR DESCRIPTION
Layout guides are no longer UIViews on iOS 9 and the view variable on ConstraintItem fails to return. In those cases try the layoutSupport property on iOS before defaulting to installOnView.