### PR TITLE
Do not assume toItem is a UIView (Fix for aligning to layout guides in iOS 9)

### DIFF
--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -241,11 +241,8 @@ internal class ConcreteConstraint: Constraint {
             let layoutConstant: CGFloat = layoutToAttribute.snp_constantForValue(self.constant)
             
             // get layout to
-            var layoutTo: View? = self.toItem.view
-            if layoutTo == nil && layoutToAttribute != .Width && layoutToAttribute != .Height {
-                layoutTo = installOnView
-            }
-            
+            let layoutTo = self.toItem.object
+
             // create layout constraint
             let layoutConstraint = LayoutConstraint(
                 item: layoutFrom!,


### PR DESCRIPTION
On iOS 9 layout guides are not UIView subclasses anymore, but instead a private type `_UILayoutSpacer`, causing `snp_topLayoutGuideBottom` etc. to break because the toItem is no longer a `UIView`. There was a check in the code that would automatically pick another view if the toItem was not a `UIView`.