### PR TITLE
Add availability check for iOS 8 and OS X 10.10 APIs.

### DIFF
--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -138,24 +138,24 @@ internal class ConcreteConstraint: Constraint {
     }
     
     internal override func activate() -> Void {
-        if NSLayoutConstraint.respondsToSelector("activateConstraints:") && self.installInfo != nil {
-            let layoutConstraints = self.installInfo!.layoutConstraints.allObjects as! [LayoutConstraint]
-            if layoutConstraints.count > 0 {
-                NSLayoutConstraint.activateConstraints(layoutConstraints)
-            }
-        } else {
+        guard #available(iOS 8.0, OSX 10.10, *), self.installInfo != nil else {
             self.install()
+            return
+        }
+        let layoutConstraints = self.installInfo!.layoutConstraints.allObjects as! [LayoutConstraint]
+        if layoutConstraints.count > 0 {
+            NSLayoutConstraint.activateConstraints(layoutConstraints)
         }
     }
     
     internal override func deactivate() -> Void {
-        if NSLayoutConstraint.respondsToSelector("deactivateConstraints:") && self.installInfo != nil {
-            let layoutConstraints = self.installInfo!.layoutConstraints.allObjects as! [LayoutConstraint]
-            if layoutConstraints.count > 0 {
-                NSLayoutConstraint.deactivateConstraints(layoutConstraints)
-            }
-        } else {
-            self.uninstall()
+        guard #available(iOS 8.0, OSX 10.10, *), self.installInfo != nil else {
+            self.install()
+            return
+        }
+        let layoutConstraints = self.installInfo!.layoutConstraints.allObjects as! [LayoutConstraint]
+        if layoutConstraints.count > 0 {
+            NSLayoutConstraint.deactivateConstraints(layoutConstraints)
         }
     }
     

--- a/Source/ConstraintAttributes.swift
+++ b/Source/ConstraintAttributes.swift
@@ -125,32 +125,34 @@ internal struct ConstraintAttributes: OptionSetType, BooleanType {
             attrs.append(.Baseline)
         }
         #if os(iOS)
-        if (self.contains(ConstraintAttributes.FirstBaseline)) {
-            attrs.append(.FirstBaseline)
-        }
-        if (self.contains(ConstraintAttributes.LeftMargin)) {
-            attrs.append(.LeftMargin)
-        }
-        if (self.contains(ConstraintAttributes.RightMargin)) {
-            attrs.append(.RightMargin)
-        }
-        if (self.contains(ConstraintAttributes.TopMargin)) {
-            attrs.append(.TopMargin)
-        }
-        if (self.contains(ConstraintAttributes.BottomMargin)) {
-            attrs.append(.BottomMargin)
-        }
-        if (self.contains(ConstraintAttributes.LeadingMargin)) {
-            attrs.append(.LeadingMargin)
-        }
-        if (self.contains(ConstraintAttributes.TrailingMargin)) {
-            attrs.append(.TrailingMargin)
-        }
-        if (self.contains(ConstraintAttributes.CenterXWithinMargins)) {
-            attrs.append(.CenterXWithinMargins)
-        }
-        if (self.contains(ConstraintAttributes.CenterYWithinMargins)) {
-            attrs.append(.CenterYWithinMargins)
+        if #available(iOS 8.0, *) {
+            if (self.contains(ConstraintAttributes.FirstBaseline)) {
+                attrs.append(.FirstBaseline)
+            }
+            if (self.contains(ConstraintAttributes.LeftMargin)) {
+                attrs.append(.LeftMargin)
+            }
+            if (self.contains(ConstraintAttributes.RightMargin)) {
+                attrs.append(.RightMargin)
+            }
+            if (self.contains(ConstraintAttributes.TopMargin)) {
+                attrs.append(.TopMargin)
+            }
+            if (self.contains(ConstraintAttributes.BottomMargin)) {
+                attrs.append(.BottomMargin)
+            }
+            if (self.contains(ConstraintAttributes.LeadingMargin)) {
+                attrs.append(.LeadingMargin)
+            }
+            if (self.contains(ConstraintAttributes.TrailingMargin)) {
+                attrs.append(.TrailingMargin)
+            }
+            if (self.contains(ConstraintAttributes.CenterXWithinMargins)) {
+                attrs.append(.CenterXWithinMargins)
+            }
+            if (self.contains(ConstraintAttributes.CenterYWithinMargins)) {
+                attrs.append(.CenterYWithinMargins)
+            }
         }
         #endif
         return attrs


### PR DESCRIPTION
SnapKit's minimum target is set to 8.0, however, it is necessary for projects that support iOS 7.

e.g. Installing via [CocoaSeeds](https://github.com/devxoul/CocoaSeeds) or drag and drop.