### PR TITLE
Added tvOS checks so the iOS paths are used rather than OS X

### DIFF
--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -21,7 +21,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 import UIKit
 #else
 import AppKit
@@ -119,7 +119,7 @@ internal class ConcreteConstraint: Constraint {
         self.updatePriority(Float(750.0))
     }
     internal override func updatePriorityMedium() -> Void {
-        #if os(iOS)
+        #if os(iOS) || os(tvOS)
         self.updatePriority(Float(500.0))
         #else
         self.updatePriority(Float(501.0))
@@ -251,7 +251,7 @@ internal class ConcreteConstraint: Constraint {
             let layoutConstant: CGFloat = layoutToAttribute.snp_constantForValue(self.constant)
             
             // get layout to
-            #if os(iOS)
+            #if os(iOS) || os(tvOS)
             var layoutTo: AnyObject? = self.toItem.view ?? self.toItem.layoutSupport
             #else
             var layoutTo: AnyObject? = self.toItem.view
@@ -397,7 +397,7 @@ private extension NSLayoutAttribute {
         }
             // CGPoint
         else if let point = value as? CGPoint {
-            #if os(iOS)
+            #if os(iOS) || os(tvOS)
                 switch self {
                 case .Left, .CenterX, .LeftMargin, .CenterXWithinMargins: return point.x
                 case .Top, .CenterY, .TopMargin, .CenterYWithinMargins, .Baseline, .FirstBaseline: return point.y
@@ -422,7 +422,7 @@ private extension NSLayoutAttribute {
         }
             // EdgeInsets
         else if let insets = value as? EdgeInsets {
-            #if os(iOS)
+            #if os(iOS) || os(tvOS)
                 switch self {
                 case .Left, .CenterX, .LeftMargin, .CenterXWithinMargins: return insets.left
                 case .Top, .CenterY, .TopMargin, .CenterYWithinMargins, .Baseline, .FirstBaseline: return insets.top

--- a/Source/ConstraintAttributes.swift
+++ b/Source/ConstraintAttributes.swift
@@ -21,7 +21,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 import UIKit
 #else
 import AppKit
@@ -133,7 +133,7 @@ internal struct ConstraintAttributes: OptionSetType, BooleanType {
             attrs.append(.Baseline)
         }
         
-        #if os(iOS)
+        #if os(iOS) || os(tvOS)
         #if SNAPKIT_DEPLOYMENT_LEGACY
         guard #available(iOS 8.0, *) else {
             return attrs

--- a/Source/ConstraintDescription.swift
+++ b/Source/ConstraintDescription.swift
@@ -21,7 +21,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 import UIKit
 #else
 import AppKit
@@ -464,7 +464,7 @@ internal class ConstraintDescription: ConstraintDescriptionExtendable, Constrain
         return self.priority(750.0)
     }
     internal func priorityMedium() -> ConstraintDescriptionFinalizable {
-        #if os(iOS)
+        #if os(iOS) || os(tvOS)
         return self.priority(500.0)
         #else
         return self.priority(501.0)

--- a/Source/ConstraintItem.swift
+++ b/Source/ConstraintItem.swift
@@ -21,7 +21,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 import UIKit
 #else
 import AppKit

--- a/Source/ConstraintMaker.swift
+++ b/Source/ConstraintMaker.swift
@@ -21,7 +21,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 import UIKit
 #else
 import AppKit

--- a/Source/ConstraintRelation.swift
+++ b/Source/ConstraintRelation.swift
@@ -21,7 +21,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 import UIKit
 #else
 import AppKit

--- a/Source/Debugging.swift
+++ b/Source/Debugging.swift
@@ -21,7 +21,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 import UIKit
 #else
 import AppKit
@@ -149,7 +149,7 @@ private extension NSLayoutRelation {
 private extension NSLayoutAttribute {
     
     private var snp_description: String {
-        #if os(iOS)
+        #if os(iOS) || os(tvOS)
         switch self {
         case .NotAnAttribute:       return "notAnAttribute"
         case .Top:                  return "top"

--- a/Source/EdgeInsets.swift
+++ b/Source/EdgeInsets.swift
@@ -21,7 +21,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 import UIKit
 public typealias EdgeInsets = UIEdgeInsets
 public func EdgeInsetsMake(top: CGFloat, left: CGFloat, bottom: CGFloat, right: CGFloat) -> EdgeInsets {

--- a/Source/LayoutConstraint.swift
+++ b/Source/LayoutConstraint.swift
@@ -21,7 +21,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 import UIKit
 #else
 import AppKit

--- a/Source/SnapKit.swift
+++ b/Source/SnapKit.swift
@@ -21,7 +21,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 import UIKit
 public typealias InterfaceLayoutDirection = UIUserInterfaceLayoutDirection
 public typealias LayoutSupport = UILayoutSupport

--- a/Source/View+SnapKit.swift
+++ b/Source/View+SnapKit.swift
@@ -21,7 +21,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 import UIKit
 public typealias View = UIView
 #else

--- a/Source/ViewController+SnapKit.swift
+++ b/Source/ViewController+SnapKit.swift
@@ -21,7 +21,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 import UIKit
 
 /**

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -1,4 +1,4 @@
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 import UIKit
 typealias View = UIView
 extension View {
@@ -30,7 +30,7 @@ class SnapKitTests: XCTestCase {
     }
     
     func testLayoutGuideConstraints() {
-        #if os(iOS)
+        #if os(iOS) || os(tvOS)
         let vc = UIViewController()
         vc.view = UIView(frame: CGRectMake(0, 0, 300, 300))
         


### PR DESCRIPTION
This adds a check for tvOS so that it uses the same code paths as iOS.

I did not add a tvos target to the podspec yet because that Cocoapods branch is still unreleased. Until then, this workaround in a Podfile is sufficient to get it up and running on tvOS:

	post_install do |installer|
			installer.pods_project.targets.each do |target|
					target.build_configurations.each do |config|
							config.build_settings['SUPPORTED_PLATFORMS'] = ['appletvos', 'appletvsimulator']
					end
			end
	end