### PR TITLE
Add call to activateConstraints on iOS8+ and fix build issues for OS X.

### DIFF
--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -315,11 +315,15 @@ internal class ConcreteConstraint: Constraint {
         }
         
         // add constraints
-        if #available(iOS 8.0, OSX 10.7, *) {
+        #if SNAPKIT_DEPLOYMENT_LEGACY && !os(OSX)
+        if #available(iOS 8.0, *) {
             NSLayoutConstraint.activateConstraints(newLayoutConstraints)
         } else {
             installOnView!.addConstraints(newLayoutConstraints)
         }
+        #else
+            NSLayoutConstraint.activateConstraints(newLayoutConstraints)
+        #endif
         
         // set install info
         self.installInfo = ConcreteConstraintInstallInfo(view: installOnView, layoutConstraints: NSHashTable.weakObjectsHashTable())
@@ -342,11 +346,15 @@ internal class ConcreteConstraint: Constraint {
                 
                 if installedLayoutConstraints.count > 0 {
                     // remove the constraints from the UIView's storage
-                    if #available(iOS 8, OSX 10.7, *) {
+                    #if SNAPKIT_DEPLOYMENT_LEGACY && !os(OSX)
+                    if #available(iOS 8.0, *) {
                         NSLayoutConstraint.deactivateConstraints(installedLayoutConstraints)
                     } else if let installedOnView = installInfo.view {
                         installedOnView.removeConstraints(installedLayoutConstraints)
                     }
+                    #else
+                        NSLayoutConstraint.deactivateConstraints(installedLayoutConstraints)
+                    #endif
                     
                     // remove the constraints from the from item view
                     if let fromView = self.fromItem.view {

--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -315,7 +315,11 @@ internal class ConcreteConstraint: Constraint {
         }
         
         // add constraints
-        installOnView!.addConstraints(newLayoutConstraints)
+        if #available(iOS 8.0, OSX 10.7, *) {
+            NSLayoutConstraint.activateConstraints(newLayoutConstraints)
+        } else {
+            installOnView!.addConstraints(newLayoutConstraints)
+        }
         
         // set install info
         self.installInfo = ConcreteConstraintInstallInfo(view: installOnView, layoutConstraints: NSHashTable.weakObjectsHashTable())
@@ -337,9 +341,10 @@ internal class ConcreteConstraint: Constraint {
             let installedLayoutConstraints = installInfo.layoutConstraints.allObjects as? [LayoutConstraint] {
                 
                 if installedLayoutConstraints.count > 0 {
-                    
-                    if let installedOnView = installInfo.view {
-                        // remove the constraints from the UIView's storage
+                    // remove the constraints from the UIView's storage
+                    if #available(iOS 8, OSX 10.7, *) {
+                        NSLayoutConstraint.deactivateConstraints(installedLayoutConstraints)
+                    } else if let installedOnView = installInfo.view {
                         installedOnView.removeConstraints(installedLayoutConstraints)
                     }
                     

--- a/Source/ConstraintDescription.swift
+++ b/Source/ConstraintDescription.swift
@@ -95,7 +95,7 @@ public protocol ConstraintDescriptionRelatable: class {
     func equalTo(other: View) -> ConstraintDescriptionEditable
     @available(iOS 7.0, *)
     func equalTo(other: LayoutSupport) -> ConstraintDescriptionEditable
-    @available(iOS 9.0, *)
+    @available(iOS 9.0, OSX 10.11, *)
     func equalTo(other: NSLayoutAnchor) -> ConstraintDescriptionEditable
     func equalTo(other: Float) -> ConstraintDescriptionEditable
     func equalTo(other: Double) -> ConstraintDescriptionEditable
@@ -110,7 +110,7 @@ public protocol ConstraintDescriptionRelatable: class {
     func lessThanOrEqualTo(other: View) -> ConstraintDescriptionEditable
     @available(iOS 7.0, *)
     func lessThanOrEqualTo(other: LayoutSupport) -> ConstraintDescriptionEditable
-    @available(iOS 9.0, *)
+    @available(iOS 9.0, OSX 10.11, *)
     func lessThanOrEqualTo(other: NSLayoutAnchor) -> ConstraintDescriptionEditable
     func lessThanOrEqualTo(other: Float) -> ConstraintDescriptionEditable
     func lessThanOrEqualTo(other: Double) -> ConstraintDescriptionEditable
@@ -125,7 +125,7 @@ public protocol ConstraintDescriptionRelatable: class {
     func greaterThanOrEqualTo(other: View) -> ConstraintDescriptionEditable
     @available(iOS 7.0, *)
     func greaterThanOrEqualTo(other: LayoutSupport) -> ConstraintDescriptionEditable
-    @available(iOS 9.0, *)
+    @available(iOS 9.0, OSX 10.11, *)
     func greaterThanOrEqualTo(other: NSLayoutAnchor) -> ConstraintDescriptionEditable
     func greaterThanOrEqualTo(other: Float) -> ConstraintDescriptionEditable
     func greaterThanOrEqualTo(other: Double) -> ConstraintDescriptionEditable
@@ -230,7 +230,7 @@ internal class ConstraintDescription: ConstraintDescriptionExtendable, Constrain
     internal func equalTo(other: LayoutSupport) -> ConstraintDescriptionEditable {
         return self.constrainTo(other, relation: .Equal)
     }
-    @available(iOS 9.0, *)
+    @available(iOS 9.0, OSX 10.11, *)
     internal func equalTo(other: NSLayoutAnchor) -> ConstraintDescriptionEditable {
         return self.constrainTo(other, relation: .Equal)
     }
@@ -271,7 +271,7 @@ internal class ConstraintDescription: ConstraintDescriptionExtendable, Constrain
     internal func lessThanOrEqualTo(other: LayoutSupport) -> ConstraintDescriptionEditable {
         return self.constrainTo(other, relation: .LessThanOrEqualTo)
     }
-    @available(iOS 9.0, *)
+    @available(iOS 9.0, OSX 10.11, *)
     internal func lessThanOrEqualTo(other: NSLayoutAnchor) -> ConstraintDescriptionEditable {
         return self.constrainTo(other, relation: .LessThanOrEqualTo)
     }
@@ -312,7 +312,7 @@ internal class ConstraintDescription: ConstraintDescriptionExtendable, Constrain
     internal func greaterThanOrEqualTo(other: LayoutSupport) -> ConstraintDescriptionEditable {
         return self.constrainTo(other, relation: .GreaterThanOrEqualTo)
     }
-    @available(iOS 9.0, *)
+    @available(iOS 9.0, OSX 10.11, *)
     internal func greaterThanOrEqualTo(other: NSLayoutAnchor) -> ConstraintDescriptionEditable {
         return self.constrainTo(other, relation: .LessThanOrEqualTo)
     }
@@ -565,7 +565,7 @@ internal class ConstraintDescription: ConstraintDescriptionExtendable, Constrain
         return constrainTo(ConstraintItem(object: other, attributes: ConstraintAttributes.None), relation: relation)
     }
     
-    @available(iOS 9.0, *)
+    @available(iOS 9.0, OSX 10.11, *)
     private func constrainTo(other: NSLayoutAnchor, relation: ConstraintRelation) -> ConstraintDescription {
         return constrainTo(ConstraintItem(object: other, attributes: ConstraintAttributes.None), relation: relation)
     }


### PR DESCRIPTION
This fixes #154 and also an issue that was introduced in last PR where it was using `NSLayoutAnchor` only available on OS X 10.11+ and thus crashing, because the target is set lower.

~~This PR brings one problem though and that is warning that the `if #available` check is not needed, because the minimum SDK is always set to **iOS 8**. I decided to leave the check in, because there is still the possibility of someone using it with **iOS 7** and the documentation states that **iOS 7** is still supported.~~