### PR TITLE
Added tvOS target for Carthage support

### DIFF
--- a/SnapKit.xcodeproj/project.pbxproj
+++ b/SnapKit.xcodeproj/project.pbxproj
@@ -7,6 +7,23 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		537DCE9B1C35CD4100B5B899 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 537DCE9A1C35CD4100B5B899 /* UIKit.framework */; };
+		537DCE9C1C35CD9A00B5B899 /* Constraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECDB35E1AC0C95C006BBC11 /* Constraint.swift */; };
+		537DCE9D1C35CDA300B5B899 /* SnapKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFCF32E1AD926AE00A425FA /* SnapKit.swift */; };
+		537DCE9E1C35CDAA00B5B899 /* Debugging.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFCF32B1AD910B900A425FA /* Debugging.swift */; };
+		537DCE9F1C35CDB700B5B899 /* ConstraintItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECDB3601AC0C95C006BBC11 /* ConstraintItem.swift */; };
+		537DCEA01C35CDF800B5B899 /* SnapKit.h in Headers */ = {isa = PBXBuildFile; fileRef = EECDB3661AC0C95C006BBC11 /* SnapKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		537DCEA11C35CE0000B5B899 /* ConstraintDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFCF3311AD9432400A425FA /* ConstraintDescription.swift */; };
+		537DCEA21C35CE0500B5B899 /* ConstraintMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECDB3611AC0C95C006BBC11 /* ConstraintMaker.swift */; };
+		537DCEA31C35CE0900B5B899 /* View+SnapKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECDB3671AC0C95C006BBC11 /* View+SnapKit.swift */; };
+		537DCEA41C35CE1500B5B899 /* ViewController+SnapKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4910971B19A26000A54F1F /* ViewController+SnapKit.swift */; };
+		537DCEA51C35CE1B00B5B899 /* EdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECDB3631AC0C95C006BBC11 /* EdgeInsets.swift */; };
+		537DCEA61C35CE2000B5B899 /* LayoutConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECDB3651AC0C95C006BBC11 /* LayoutConstraint.swift */; };
+		537DCEA81C35CE3800B5B899 /* ConstraintRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECDB3621AC0C95C006BBC11 /* ConstraintRelation.swift */; };
+		537DCEA91C35CE3E00B5B899 /* ConstraintAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECDB35F1AC0C95C006BBC11 /* ConstraintAttributes.swift */; };
+		537DCEAA1C35CE4800B5B899 /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779230431BCB6FC30027CF5F /* SourceLocation.swift */; };
+		537DCEB41C35D90A00B5B899 /* SnapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 537DCE921C35CC8800B5B899 /* SnapKit.framework */; };
+		537DCEBA1C35DA9700B5B899 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECDB36A1AC0C95C006BBC11 /* Tests.swift */; };
 		779230441BCB6FC30027CF5F /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779230431BCB6FC30027CF5F /* SourceLocation.swift */; };
 		779230451BCB6FC30027CF5F /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779230431BCB6FC30027CF5F /* SourceLocation.swift */; };
 		EE4910981B19A26000A54F1F /* ViewController+SnapKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4910971B19A26000A54F1F /* ViewController+SnapKit.swift */; };
@@ -53,6 +70,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		537DCE921C35CC8800B5B899 /* SnapKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SnapKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		537DCE9A1C35CD4100B5B899 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS9.1.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		537DCEAF1C35D90A00B5B899 /* SnapKit tvOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SnapKit tvOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		779230431BCB6FC30027CF5F /* SourceLocation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SourceLocation.swift; sourceTree = "<group>"; };
 		EE4910971B19A26000A54F1F /* ViewController+SnapKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ViewController+SnapKit.swift"; sourceTree = "<group>"; };
 		EE94F6081AC0F10A008767FF /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
@@ -79,6 +99,22 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		537DCE8E1C35CC8800B5B899 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				537DCE9B1C35CD4100B5B899 /* UIKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		537DCEAC1C35D90A00B5B899 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				537DCEB41C35D90A00B5B899 /* SnapKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EE94F60D1AC0F132008767FF /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -130,6 +166,8 @@
 				EEBCC9E219CC627E0083B827 /* SnapKit iOS Tests.xctest */,
 				EECDB37A1AC0C9D4006BBC11 /* SnapKit.framework */,
 				EECDB3841AC0C9D4006BBC11 /* SnapKit OSX Tests.xctest */,
+				537DCE921C35CC8800B5B899 /* SnapKit.framework */,
+				537DCEAF1C35D90A00B5B899 /* SnapKit tvOS Tests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -137,6 +175,7 @@
 		EE94F60C1AC0F113008767FF /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				537DCE9A1C35CD4100B5B899 /* UIKit.framework */,
 				EE94F60A1AC0F10F008767FF /* AppKit.framework */,
 				EE94F6081AC0F10A008767FF /* UIKit.framework */,
 			);
@@ -187,6 +226,14 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		537DCE8F1C35CC8800B5B899 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				537DCEA01C35CDF800B5B899 /* SnapKit.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EEBCC9D519CC627D0083B827 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -206,6 +253,41 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		537DCE911C35CC8800B5B899 /* SnapKit tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 537DCE991C35CC8800B5B899 /* Build configuration list for PBXNativeTarget "SnapKit tvOS" */;
+			buildPhases = (
+				537DCE8D1C35CC8800B5B899 /* Sources */,
+				537DCE8E1C35CC8800B5B899 /* Frameworks */,
+				537DCE8F1C35CC8800B5B899 /* Headers */,
+				537DCE901C35CC8800B5B899 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SnapKit tvOS";
+			productName = "SnapKit tvOS";
+			productReference = 537DCE921C35CC8800B5B899 /* SnapKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		537DCEAE1C35D90A00B5B899 /* SnapKit tvOS Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 537DCEB91C35D90A00B5B899 /* Build configuration list for PBXNativeTarget "SnapKit tvOS Tests" */;
+			buildPhases = (
+				537DCEAB1C35D90A00B5B899 /* Sources */,
+				537DCEAC1C35D90A00B5B899 /* Frameworks */,
+				537DCEAD1C35D90A00B5B899 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SnapKit tvOS Tests";
+			productName = "SnapKit tvOS Tests";
+			productReference = 537DCEAF1C35D90A00B5B899 /* SnapKit tvOS Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		EEBCC9D719CC627D0083B827 /* SnapKit iOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = EEBCC9E819CC627E0083B827 /* Build configuration list for PBXNativeTarget "SnapKit iOS" */;
@@ -283,10 +365,16 @@
 		DDC9FD8D1981B4DD009612C7 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0700;
+				LastSwiftUpdateCheck = 0720;
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "SnapKit Team";
 				TargetAttributes = {
+					537DCE911C35CC8800B5B899 = {
+						CreatedOnToolsVersion = 7.2;
+					};
+					537DCEAE1C35D90A00B5B899 = {
+						CreatedOnToolsVersion = 7.2;
+					};
 					EEBCC9D719CC627D0083B827 = {
 						CreatedOnToolsVersion = 6.0;
 					};
@@ -315,14 +403,30 @@
 			projectRoot = "";
 			targets = (
 				EEBCC9D719CC627D0083B827 /* SnapKit iOS */,
+				537DCE911C35CC8800B5B899 /* SnapKit tvOS */,
 				EECDB3791AC0C9D4006BBC11 /* SnapKit OSX */,
 				EEBCC9E119CC627D0083B827 /* SnapKit iOS Tests */,
+				537DCEAE1C35D90A00B5B899 /* SnapKit tvOS Tests */,
 				EECDB3831AC0C9D4006BBC11 /* SnapKit OSX Tests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		537DCE901C35CC8800B5B899 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		537DCEAD1C35D90A00B5B899 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EEBCC9D619CC627D0083B827 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -354,6 +458,34 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		537DCE8D1C35CC8800B5B899 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				537DCEA61C35CE2000B5B899 /* LayoutConstraint.swift in Sources */,
+				537DCE9F1C35CDB700B5B899 /* ConstraintItem.swift in Sources */,
+				537DCEA81C35CE3800B5B899 /* ConstraintRelation.swift in Sources */,
+				537DCE9D1C35CDA300B5B899 /* SnapKit.swift in Sources */,
+				537DCEA51C35CE1B00B5B899 /* EdgeInsets.swift in Sources */,
+				537DCE9C1C35CD9A00B5B899 /* Constraint.swift in Sources */,
+				537DCEA41C35CE1500B5B899 /* ViewController+SnapKit.swift in Sources */,
+				537DCE9E1C35CDAA00B5B899 /* Debugging.swift in Sources */,
+				537DCEA11C35CE0000B5B899 /* ConstraintDescription.swift in Sources */,
+				537DCEAA1C35CE4800B5B899 /* SourceLocation.swift in Sources */,
+				537DCEA91C35CE3E00B5B899 /* ConstraintAttributes.swift in Sources */,
+				537DCEA31C35CE0900B5B899 /* View+SnapKit.swift in Sources */,
+				537DCEA21C35CE0500B5B899 /* ConstraintMaker.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		537DCEAB1C35D90A00B5B899 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				537DCEBA1C35DA9700B5B899 /* Tests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EEBCC9D319CC627D0083B827 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -420,6 +552,84 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		537DCE971C35CC8800B5B899 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = io.snapkit.SnapKit;
+				PRODUCT_NAME = SnapKit;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		537DCE981C35CC8800B5B899 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = io.snapkit.SnapKit;
+				PRODUCT_NAME = SnapKit;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		537DCEB71C35D90A00B5B899 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Tests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.snapkit.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.1;
+			};
+			name = Debug;
+		};
+		537DCEB81C35D90A00B5B899 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Tests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.snapkit.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.1;
+			};
+			name = Release;
+		};
 		DDC9FDAF1981B4DD009612C7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -652,6 +862,23 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		537DCE991C35CC8800B5B899 /* Build configuration list for PBXNativeTarget "SnapKit tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				537DCE971C35CC8800B5B899 /* Debug */,
+				537DCE981C35CC8800B5B899 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		537DCEB91C35D90A00B5B899 /* Build configuration list for PBXNativeTarget "SnapKit tvOS Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				537DCEB71C35D90A00B5B899 /* Debug */,
+				537DCEB81C35D90A00B5B899 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		DDC9FD901981B4DD009612C7 /* Build configuration list for PBXProject "SnapKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/SnapKit.xcodeproj/xcshareddata/xcschemes/SnapKit tvOS.xcscheme
+++ b/SnapKit.xcodeproj/xcshareddata/xcschemes/SnapKit tvOS.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "537DCE911C35CC8800B5B899"
+               BuildableName = "SnapKit.framework"
+               BlueprintName = "SnapKit tvOS"
+               ReferencedContainer = "container:SnapKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "537DCEAE1C35D90A00B5B899"
+               BuildableName = "SnapKit tvOS Tests.xctest"
+               BlueprintName = "SnapKit tvOS Tests"
+               ReferencedContainer = "container:SnapKit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "537DCE911C35CC8800B5B899"
+            BuildableName = "SnapKit.framework"
+            BlueprintName = "SnapKit tvOS"
+            ReferencedContainer = "container:SnapKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "537DCE911C35CC8800B5B899"
+            BuildableName = "SnapKit.framework"
+            BlueprintName = "SnapKit tvOS"
+            ReferencedContainer = "container:SnapKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "537DCE911C35CC8800B5B899"
+            BuildableName = "SnapKit.framework"
+            BlueprintName = "SnapKit tvOS"
+            ReferencedContainer = "container:SnapKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Carthage is complaining about tvOS target missing;

when you do `carthage update --platform tvOS` it outputs;

```
Dependency "SnapKit" has no shared framework schemes for any of the platforms: tvOS

If you believe this to be an error, please file an issue with the maintainers at https://github.com/SnapKit/SnapKit/issues/new
```
Creating tvOS target fixes the problem.

Also added tests just as other targets.