### PR TITLE
Fix handling of UIEdgeInsets for width and height

### DIFF
--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -445,7 +445,9 @@ private extension NSLayoutAttribute {
                 case .Bottom, .BottomMargin: return insets.bottom
                 case .Leading, .LeadingMargin: return  (Config.interfaceLayoutDirection == .LeftToRight) ? insets.left : -insets.right
                 case .Trailing, .TrailingMargin: return  (Config.interfaceLayoutDirection == .LeftToRight) ? insets.right : -insets.left
-                case .Width, .Height, .NotAnAttribute: return CGFloat(0)
+                case .Width: return -insets.left + insets.right
+                case .Height: return -insets.top + insets.bottom
+                case .NotAnAttribute: return CGFloat(0)
                 }
             #else
                 switch self {
@@ -455,7 +457,9 @@ private extension NSLayoutAttribute {
                 case .Bottom: return insets.bottom
                 case .Leading: return  (Config.interfaceLayoutDirection == .LeftToRight) ? insets.left : -insets.right
                 case .Trailing: return  (Config.interfaceLayoutDirection == .LeftToRight) ? insets.right : -insets.left
-                case .Width, .Height, .NotAnAttribute: return CGFloat(0)
+                case .Width: return -insets.left + insets.right
+                case .Height: return -insets.top + insets.bottom
+                case .NotAnAttribute: return CGFloat(0)
                 case .FirstBaseline: return insets.bottom
                 }
             #endif


### PR DESCRIPTION
Intuitively, the following two constraints seem like they should behave the same way:

```swift
let insets = UIEdgeInsets(20, 20, 20, 20)

/// #1
make.left.right.equalTo(superview).inset(insets)

/// #2
make.left.equalTo(superview).inset(insets)
make.width.equalTo(superview).inset(insets)
```

In other words, insetting a width with a UIEdgeInsets should shorten it by the `.left` and `.right`