### PR TITLE
Removed Prefixed APIs

### DIFF
--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -178,7 +178,7 @@ internal class ConcreteConstraint: Constraint {
             if let installInfo = self.installInfo {
                 for layoutConstraint in installInfo.layoutConstraints.allObjects as! [LayoutConstraint] {
                     let attribute = (layoutConstraint.secondAttribute == .NotAnAttribute) ? layoutConstraint.firstAttribute : layoutConstraint.secondAttribute
-                    layoutConstraint.constant = attribute.snp_constantForValue(self.constant)
+                    layoutConstraint.constant = attribute.constantForValue(self.constant)
                 }
             }
         }
@@ -251,7 +251,7 @@ internal class ConcreteConstraint: Constraint {
             let layoutToAttribute = (layoutToAttributes.count > 0) ? layoutToAttributes[0] : layoutFromAttribute
             
             // get layout constant
-            let layoutConstant: CGFloat = layoutToAttribute.snp_constantForValue(self.constant)
+            let layoutConstant: CGFloat = layoutToAttribute.constantForValue(self.constant)
             
             // get layout to
             #if os(iOS) || os(tvOS)
@@ -278,7 +278,7 @@ internal class ConcreteConstraint: Constraint {
             layoutConstraint.priority = self.priority
             
             // set constraint
-            layoutConstraint.snp_constraint = self
+            layoutConstraint.constraint = self
             
             newLayoutConstraints.append(layoutConstraint)
         }
@@ -286,7 +286,7 @@ internal class ConcreteConstraint: Constraint {
         // special logic for updating
         if updateExisting {
             // get existing constraints for this view
-            let existingLayoutConstraints = layoutFrom!.snp_installedLayoutConstraints.reverse()
+            let existingLayoutConstraints = layoutFrom!.installedLayoutConstraints.reverse()
             
             // array that will contain only new layout constraints to keep
             var newLayoutConstraintsToKeep = [LayoutConstraint]()
@@ -338,7 +338,7 @@ internal class ConcreteConstraint: Constraint {
         }
         
         // store the layout constraints against the layout from view
-        layoutFrom!.snp_installedLayoutConstraints += newLayoutConstraints
+        layoutFrom!.installedLayoutConstraints += newLayoutConstraints
         
         // return the new constraints
         return newLayoutConstraints
@@ -362,7 +362,7 @@ internal class ConcreteConstraint: Constraint {
                     
                     // remove the constraints from the from item view
                     if let fromView = self.fromItem.view {
-                        fromView.snp_installedLayoutConstraints = fromView.snp_installedLayoutConstraints.filter {
+                        fromView.installedLayoutConstraints = fromView.installedLayoutConstraints.filter {
                             return !installedLayoutConstraints.contains($0)
                         }
                     }
@@ -383,7 +383,7 @@ private struct ConcreteConstraintInstallInfo {
 
 private extension NSLayoutAttribute {
     
-    private func snp_constantForValue(value: Any?) -> CGFloat {
+    private func constantForValue(value: Any?) -> CGFloat {
         // Float
         if let float = value as? Float {
             return CGFloat(float)

--- a/Source/ConstraintMaker.swift
+++ b/Source/ConstraintMaker.swift
@@ -189,8 +189,8 @@ public class ConstraintMaker {
     }
     
     internal class func removeConstraints(view view: View) {
-        for existingLayoutConstraint in view.snp_installedLayoutConstraints {
-            existingLayoutConstraint.snp_constraint?.uninstall()
+        for existingLayoutConstraint in view.installedLayoutConstraints {
+            existingLayoutConstraint.constraint?.uninstall()
         }
     }
 }

--- a/Source/Debugging.swift
+++ b/Source/Debugging.swift
@@ -28,11 +28,11 @@ import AppKit
 #endif
 
 /**
-    Used to allow adding a snp_label to a View for debugging purposes
+    Used to allow adding a label to a View for debugging purposes
 */
 public extension View {
     
-    public var snp_label: String? {
+    @objc(snp_label) public var label: String? {
         get {
             return objc_getAssociatedObject(self, &labelKey) as? String
         }
@@ -44,11 +44,11 @@ public extension View {
 }
 
 /**
-    Used to allow adding a snp_label to a LayoutConstraint for debugging purposes
+    Used to allow adding a label to a LayoutConstraint for debugging purposes
 */
 public extension LayoutConstraint {
     
-    public var snp_label: String? {
+    @objc(snp_label) public var label: String? {
         get {
             return objc_getAssociatedObject(self, &labelKey) as? String
         }
@@ -64,17 +64,17 @@ public extension LayoutConstraint {
         
         description += " \(descriptionForObject(self.firstItem))"
         if self.firstAttribute != .NotAnAttribute {
-            description += ".\(self.firstAttribute.snp_description)"
+            description += ".\(self.firstAttribute.description)"
         }
         
-        description += " \(self.relation.snp_description)"
+        description += " \(self.relation.description)"
         
         if let secondItem: AnyObject = self.secondItem {
             description += " \(descriptionForObject(secondItem))"
         }
         
         if self.secondAttribute != .NotAnAttribute {
-            description += ".\(self.secondAttribute.snp_description)"
+            description += ".\(self.secondAttribute.description)"
         }
         
         if self.multiplier != 1.0 {
@@ -100,12 +100,12 @@ public extension LayoutConstraint {
         return description
     }
     
-    internal var snp_makerFile: String? {
-        return self.snp_constraint?.makerFile
+    @objc(snp_makerFile) internal var makerFile: String? {
+        return self.constraint?.makerFile
     }
     
-    internal var snp_makerLine: UInt? {
-        return self.snp_constraint?.makerLine
+    internal var makerLine: UInt? {
+        return self.constraint?.makerLine
     }
     
 }
@@ -119,14 +119,14 @@ private func descriptionForObject(object: AnyObject) -> String {
     desc += object.dynamicType.description()
     
     if let object = object as? View {
-        desc += ":\(object.snp_label ?? pointerDescription)"
+        desc += ":\(object.label ?? pointerDescription)"
     } else if let object = object as? LayoutConstraint {
-        desc += ":\(object.snp_label ?? pointerDescription)"
+        desc += ":\(object.label ?? pointerDescription)"
     } else {
         desc += ":\(pointerDescription)"
     }
     
-    if let object = object as? LayoutConstraint, let file = object.snp_makerFile, let line = object.snp_makerLine {
+    if let object = object as? LayoutConstraint, let file = object.makerFile, let line = object.makerLine {
         desc += "@\(file)#\(line)"
     }
     
@@ -136,7 +136,7 @@ private func descriptionForObject(object: AnyObject) -> String {
 
 private extension NSLayoutRelation {
     
-    private var snp_description: String {
+    private var description: String {
         switch self {
         case .Equal:                return "=="
         case .GreaterThanOrEqual:   return ">="
@@ -148,7 +148,7 @@ private extension NSLayoutRelation {
 
 private extension NSLayoutAttribute {
     
-    private var snp_description: String {
+    private var description: String {
         #if os(iOS) || os(tvOS)
         switch self {
         case .NotAnAttribute:       return "notAnAttribute"

--- a/Source/LayoutConstraint.swift
+++ b/Source/LayoutConstraint.swift
@@ -32,7 +32,7 @@ import AppKit
 */
 public class LayoutConstraint: NSLayoutConstraint {
     
-    internal var snp_constraint: Constraint? = nil
+    internal var constraint: Constraint? = nil
     
 }
 

--- a/Source/View+SnapKit.swift
+++ b/Source/View+SnapKit.swift
@@ -35,90 +35,90 @@ public typealias View = NSView
 public extension View {
     
     /// left edge
-    public var snp_left: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Left) }
+    public var left: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Left) }
     
     /// top edge
-    public var snp_top: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Top) }
+    public var top: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Top) }
     
     /// right edge
-    public var snp_right: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Right) }
+    public var right: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Right) }
     
     /// bottom edge
-    public var snp_bottom: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Bottom) }
+    public var bottom: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Bottom) }
     
     /// leading edge
-    public var snp_leading: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Leading) }
+    public var leading: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Leading) }
     
     /// trailing edge
-    public var snp_trailing: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Trailing) }
+    public var trailing: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Trailing) }
     
     /// width dimension
-    public var snp_width: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Width) }
+    public var width: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Width) }
     
     /// height dimension
-    public var snp_height: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Height) }
+    public var height: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Height) }
     
     /// centerX position
-    public var snp_centerX: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.CenterX) }
+    public var centerX: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.CenterX) }
     
     /// centerY position
-    public var snp_centerY: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.CenterY) }
+    public var centerY: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.CenterY) }
     
     /// baseline position
-    public var snp_baseline: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Baseline) }
+    public var baseline: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Baseline) }
     
     /// first baseline position
     @available(iOS 8.0, *)
-    public var snp_firstBaseline: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.FirstBaseline) }
+    public var firstBaseline: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.FirstBaseline) }
     
     /// left margin
     @available(iOS 8.0, *)
-    public var snp_leftMargin: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.LeftMargin) }
+    public var leftMargin: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.LeftMargin) }
     
     /// right margin
     @available(iOS 8.0, *)
-    public var snp_rightMargin: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.RightMargin) }
+    public var rightMargin: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.RightMargin) }
     
     /// top margin
     @available(iOS 8.0, *)
-    public var snp_topMargin: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.TopMargin) }
+    public var topMargin: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.TopMargin) }
     
     /// bottom margin
     @available(iOS 8.0, *)
-    public var snp_bottomMargin: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.BottomMargin) }
+    public var bottomMargin: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.BottomMargin) }
     
     /// leading margin
     @available(iOS 8.0, *)
-    public var snp_leadingMargin: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.LeadingMargin) }
+    public var leadingMargin: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.LeadingMargin) }
     
     /// trailing margin
     @available(iOS 8.0, *)
-    public var snp_trailingMargin: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.TrailingMargin) }
+    public var trailingMargin: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.TrailingMargin) }
     
     /// centerX within margins
     @available(iOS 8.0, *)
-    public var snp_centerXWithinMargins: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.CenterXWithinMargins) }
+    public var centerXWithinMargins: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.CenterXWithinMargins) }
     
     /// centerY within margins
     @available(iOS 8.0, *)
-    public var snp_centerYWithinMargins: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.CenterYWithinMargins) }
+    public var centerYWithinMargins: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.CenterYWithinMargins) }
     
     // top + left + bottom + right edges
-    public var snp_edges: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Edges) }
+    public var edges: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Edges) }
     
     // width + height dimensions
-    public var snp_size: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Size) }
+    public var size: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Size) }
     
     // centerX + centerY positions
-    public var snp_center: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Center) }
+    public var center: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Center) }
     
     // top + left + bottom + right margins
     @available(iOS 8.0, *)
-    public var snp_margins: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Margins) }
+    public var margins: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.Margins) }
     
     // centerX + centerY within margins
     @available(iOS 8.0, *)
-    public var snp_centerWithinMargins: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.CenterWithinMargins) }
+    public var centerWithinMargins: ConstraintItem { return ConstraintItem(object: self, attributes: ConstraintAttributes.CenterWithinMargins) }
     
     /**
         Prepares constraints with a `ConstraintMaker` and returns the made constraints but does not install them.
@@ -127,7 +127,7 @@ public extension View {
         
         :returns: the constraints made
     */
-    public func snp_prepareConstraints(file: String = #file, line: UInt = #line, @noescape closure: (make: ConstraintMaker) -> Void) -> [Constraint] {
+    public func prepareConstraints(file: String = #file, line: UInt = #line, @noescape closure: (make: ConstraintMaker) -> Void) -> [Constraint] {
         return ConstraintMaker.prepareConstraints(view: self, file: file, line: line, closure: closure)
     }
     
@@ -136,7 +136,7 @@ public extension View {
         
         :param: closure that will be passed the `ConstraintMaker` to make the constraints with
     */
-    public func snp_makeConstraints(file: String = #file, line: UInt = #line, @noescape closure: (make: ConstraintMaker) -> Void) -> Void {
+    public func makeConstraints(file: String = #file, line: UInt = #line, @noescape closure: (make: ConstraintMaker) -> Void) -> Void {
         ConstraintMaker.makeConstraints(view: self, file: file, line: line, closure: closure)
     }
     
@@ -147,7 +147,7 @@ public extension View {
     
         :param: closure that will be passed the `ConstraintMaker` to update the constraints with
     */
-    public func snp_updateConstraints(file: String = #file, line: UInt = #line, @noescape closure: (make: ConstraintMaker) -> Void) -> Void {
+    public func updateConstraints(file: String = #file, line: UInt = #line, @noescape closure: (make: ConstraintMaker) -> Void) -> Void {
         ConstraintMaker.updateConstraints(view: self, file: file, line: line, closure: closure)
     }
     
@@ -156,18 +156,18 @@ public extension View {
     
         :param: closure that will be passed the `ConstraintMaker` to remake the constraints with
     */
-    public func snp_remakeConstraints(file: String = #file, line: UInt = #line, @noescape closure: (make: ConstraintMaker) -> Void) -> Void {
+    public func remakeConstraints(file: String = #file, line: UInt = #line, @noescape closure: (make: ConstraintMaker) -> Void) -> Void {
         ConstraintMaker.remakeConstraints(view: self, file: file, line: line, closure: closure)
     }
     
     /**
         Removes all previously made constraints.
     */
-    public func snp_removeConstraints() {
+    @objc(snp_removeConstraints) public func removeConstraints() {
         ConstraintMaker.removeConstraints(view: self)
     }
     
-    internal var snp_installedLayoutConstraints: [LayoutConstraint] {
+    internal var installedLayoutConstraints: [LayoutConstraint] {
         get {
             if let constraints = objc_getAssociatedObject(self, &installedLayoutConstraintsKey) as? [LayoutConstraint] {
                 return constraints

--- a/Source/ViewController+SnapKit.swift
+++ b/Source/ViewController+SnapKit.swift
@@ -30,16 +30,16 @@ import UIKit
 public extension UIViewController {
     
     /// top layout guide top
-    public var snp_topLayoutGuideTop: ConstraintItem { return ConstraintItem(object: self.topLayoutGuide, attributes: ConstraintAttributes.Top) }
+    public var topLayoutGuideTop: ConstraintItem { return ConstraintItem(object: self.topLayoutGuide, attributes: ConstraintAttributes.Top) }
     
     /// top layout guide bottom
-    public var snp_topLayoutGuideBottom: ConstraintItem { return ConstraintItem(object: self.topLayoutGuide, attributes: ConstraintAttributes.Bottom) }
+    public var topLayoutGuideBottom: ConstraintItem { return ConstraintItem(object: self.topLayoutGuide, attributes: ConstraintAttributes.Bottom) }
     
     /// bottom layout guide top
-    public var snp_bottomLayoutGuideTop: ConstraintItem { return ConstraintItem(object: self.bottomLayoutGuide, attributes: ConstraintAttributes.Top) }
+    public var bottomLayoutGuideTop: ConstraintItem { return ConstraintItem(object: self.bottomLayoutGuide, attributes: ConstraintAttributes.Top) }
     
     /// bottom layout guide bottom
-    public var snp_bottomLayoutGuideBottom: ConstraintItem { return ConstraintItem(object: self.bottomLayoutGuide, attributes: ConstraintAttributes.Bottom) }
+    public var bottomLayoutGuideBottom: ConstraintItem { return ConstraintItem(object: self.bottomLayoutGuide, attributes: ConstraintAttributes.Bottom) }
     
 }
 #endif

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -1,17 +1,3 @@
-#if os(iOS) || os(tvOS)
-import UIKit
-typealias View = UIView
-extension View {
-    var snp_constraints: [AnyObject] { return self.constraints }
-}
-#else
-import AppKit
-typealias View = NSView
-extension View {
-    var snp_constraints: [AnyObject] { return self.constraints }
-}
-#endif
-
 import XCTest
 import SnapKit
 
@@ -36,12 +22,12 @@ class SnapKitTests: XCTestCase {
         
         vc.view.addSubview(self.container)
         
-        self.container.snp_makeConstraints { (make) -> Void in
-            make.top.equalTo(vc.snp_topLayoutGuideBottom)
-            make.bottom.equalTo(vc.snp_bottomLayoutGuideTop)
+        self.container.makeConstraints { (make) -> Void in
+            make.top.equalTo(vc.topLayoutGuideBottom)
+            make.bottom.equalTo(vc.bottomLayoutGuideTop)
         }
         
-        XCTAssertEqual(vc.view.snp_constraints.count, 6, "Should have 6 constraints installed")
+        XCTAssertEqual(vc.view.constraints.count, 6, "Should have 6 constraints installed")
         #endif
     }
     
@@ -51,20 +37,20 @@ class SnapKitTests: XCTestCase {
         self.container.addSubview(v1)
         self.container.addSubview(v2)
         
-        v1.snp_makeConstraints { (make) -> Void in
-            make.top.equalTo(v2.snp_top).offset(50)
-            make.left.equalTo(v2.snp_top).offset(50)
+        v1.makeConstraints { (make) -> Void in
+            make.top.equalTo(v2.top).offset(50)
+            make.left.equalTo(v2.top).offset(50)
             return
         }
         
-        XCTAssertEqual(self.container.snp_constraints.count, 2, "Should have 2 constraints installed")
+        XCTAssertEqual(self.container.constraints.count, 2, "Should have 2 constraints installed")
         
-        v2.snp_makeConstraints { (make) -> Void in
+        v2.makeConstraints { (make) -> Void in
             make.edges.equalTo(v1)
             return
         }
         
-        XCTAssertEqual(self.container.snp_constraints.count, 6, "Should have 6 constraints installed")
+        XCTAssertEqual(self.container.constraints.count, 6, "Should have 6 constraints installed")
         
     }
     
@@ -74,20 +60,20 @@ class SnapKitTests: XCTestCase {
         self.container.addSubview(v1)
         self.container.addSubview(v2)
         
-        v1.snp_makeConstraints { (make) -> Void in
-            make.top.equalTo(v2.snp_top).offset(50)
-            make.left.equalTo(v2.snp_top).offset(50)
+        v1.makeConstraints { (make) -> Void in
+            make.top.equalTo(v2.top).offset(50)
+            make.left.equalTo(v2.top).offset(50)
             return
         }
         
-        XCTAssertEqual(self.container.snp_constraints.count, 2, "Should have 2 constraints installed")
+        XCTAssertEqual(self.container.constraints.count, 2, "Should have 2 constraints installed")
         
-        v1.snp_updateConstraints { (make) -> Void in
-            make.top.equalTo(v2.snp_top).offset(15)
+        v1.updateConstraints { (make) -> Void in
+            make.top.equalTo(v2.top).offset(15)
             return
         }
         
-        XCTAssertEqual(self.container.snp_constraints.count, 2, "Should still have 2 constraints installed")
+        XCTAssertEqual(self.container.constraints.count, 2, "Should still have 2 constraints installed")
         
     }
     
@@ -97,20 +83,20 @@ class SnapKitTests: XCTestCase {
         self.container.addSubview(v1)
         self.container.addSubview(v2)
         
-        v1.snp_makeConstraints { (make) -> Void in
-            make.top.equalTo(v2.snp_top).offset(50)
-            make.left.equalTo(v2.snp_top).offset(50)
+        v1.makeConstraints { (make) -> Void in
+            make.top.equalTo(v2.top).offset(50)
+            make.left.equalTo(v2.top).offset(50)
             return
         }
         
-        XCTAssertEqual(self.container.snp_constraints.count, 2, "Should have 2 constraints installed")
+        XCTAssertEqual(self.container.constraints.count, 2, "Should have 2 constraints installed")
         
-        v1.snp_remakeConstraints { (make) -> Void in
+        v1.remakeConstraints { (make) -> Void in
             make.edges.equalTo(v2)
             return
         }
         
-        XCTAssertEqual(self.container.snp_constraints.count, 4, "Should have 4 constraints installed")
+        XCTAssertEqual(self.container.constraints.count, 4, "Should have 4 constraints installed")
         
     }
     
@@ -120,17 +106,17 @@ class SnapKitTests: XCTestCase {
         self.container.addSubview(v1)
         self.container.addSubview(v2)
         
-        v1.snp_makeConstraints { (make) -> Void in
-            make.top.equalTo(v2.snp_top).offset(50)
-            make.left.equalTo(v2.snp_top).offset(50)
+        v1.makeConstraints { (make) -> Void in
+            make.top.equalTo(v2.top).offset(50)
+            make.left.equalTo(v2.top).offset(50)
             return
         }
         
-        XCTAssertEqual(self.container.snp_constraints.count, 2, "Should have 2 constraints installed")
+        XCTAssertEqual(self.container.constraints.count, 2, "Should have 2 constraints installed")
         
-        v1.snp_removeConstraints()
+        v1.removeConstraints()
         
-        XCTAssertEqual(self.container.snp_constraints.count, 0, "Should have 0 constraints installed")
+        XCTAssertEqual(self.container.constraints.count, 0, "Should have 0 constraints installed")
         
     }
     
@@ -140,24 +126,24 @@ class SnapKitTests: XCTestCase {
         self.container.addSubview(v1)
         self.container.addSubview(v2)
         
-        let constraints = v1.snp_prepareConstraints { (make) -> Void in
+        let constraints = v1.prepareConstraints { (make) -> Void in
             make.edges.equalTo(v2)
             return
         }
         
-        XCTAssertEqual(self.container.snp_constraints.count, 0, "Should have 0 constraints installed")
+        XCTAssertEqual(self.container.constraints.count, 0, "Should have 0 constraints installed")
         
         for constraint in constraints {
             constraint.install()
         }
         
-        XCTAssertEqual(self.container.snp_constraints.count, 4, "Should have 4 constraints installed")
+        XCTAssertEqual(self.container.constraints.count, 4, "Should have 4 constraints installed")
         
         for constraint in constraints {
             constraint.uninstall()
         }
         
-        XCTAssertEqual(self.container.snp_constraints.count, 0, "Should have 0 constraints installed")
+        XCTAssertEqual(self.container.constraints.count, 0, "Should have 0 constraints installed")
         
     }
     
@@ -167,25 +153,25 @@ class SnapKitTests: XCTestCase {
         self.container.addSubview(v1)
         self.container.addSubview(v2)
         
-        let constraints = v1.snp_prepareConstraints { (make) -> Void in
+        let constraints = v1.prepareConstraints { (make) -> Void in
             make.edges.equalTo(v2)
             return
         }
         
         
-        XCTAssertEqual(self.container.snp_constraints.count, 0, "Should have 0 constraints installed")
+        XCTAssertEqual(self.container.constraints.count, 0, "Should have 0 constraints installed")
         
         for constraint in constraints {
             constraint.install()
         }
         
-        XCTAssertEqual(self.container.snp_constraints.count, 4, "Should have 4 constraints installed")
+        XCTAssertEqual(self.container.constraints.count, 4, "Should have 4 constraints installed")
         
         for constraint in constraints {
             constraint.install()
         }
         
-        XCTAssertEqual(self.container.snp_constraints.count, 4, "Should have 0 constraints installed")
+        XCTAssertEqual(self.container.constraints.count, 4, "Should have 0 constraints installed")
     }
     
     func testActivateDeactivateConstraints() {
@@ -197,33 +183,33 @@ class SnapKitTests: XCTestCase {
         var c1: Constraint? = nil
         var c2: Constraint? = nil
         
-        v1.snp_prepareConstraints { (make) -> Void in
-            c1 = make.top.equalTo(v2.snp_top).offset(50).constraint
-            c2 = make.left.equalTo(v2.snp_top).offset(50).constraint
+        v1.prepareConstraints { (make) -> Void in
+            c1 = make.top.equalTo(v2.top).offset(50).constraint
+            c2 = make.left.equalTo(v2.top).offset(50).constraint
             return
         }
         
-        XCTAssertEqual(self.container.snp_constraints.count, 0, "Should have 0 constraints")
+        XCTAssertEqual(self.container.constraints.count, 0, "Should have 0 constraints")
         
         c1?.activate()
         c2?.activate()
         
-        XCTAssertEqual(self.container.snp_constraints.count, 2, "Should have 2 constraints")
+        XCTAssertEqual(self.container.constraints.count, 2, "Should have 2 constraints")
         
         c1?.deactivate()
         c2?.deactivate()
         
-        XCTAssertEqual(self.container.snp_constraints.count, 0, "Should have 0 constraints")
+        XCTAssertEqual(self.container.constraints.count, 0, "Should have 0 constraints")
         
         c1?.uninstall()
         c2?.uninstall()
         
-        XCTAssertEqual(self.container.snp_constraints.count, 0, "Should have 0 constraints")
+        XCTAssertEqual(self.container.constraints.count, 0, "Should have 0 constraints")
         
         c1?.activate()
         c2?.activate()
         
-        XCTAssertEqual(self.container.snp_constraints.count, 2, "Should have 2 constraints")
+        XCTAssertEqual(self.container.constraints.count, 2, "Should have 2 constraints")
         
     }
     
@@ -231,17 +217,17 @@ class SnapKitTests: XCTestCase {
         let view = View()
         self.container.addSubview(view)
         
-        view.snp_makeConstraints { (make) -> Void in
+        view.makeConstraints { (make) -> Void in
             make.size.equalTo(CGSizeMake(50, 50))
             make.left.top.equalTo(self.container)
         }
         
-        XCTAssertEqual(view.snp_constraints.count, 2, "Should have 2 constraints")
+        XCTAssertEqual(view.constraints.count, 2, "Should have 2 constraints")
         
-        XCTAssertEqual(self.container.snp_constraints.count, 2, "Should have 2 constraints")
+        XCTAssertEqual(self.container.constraints.count, 2, "Should have 2 constraints")
         
         
-        let constraints = view.snp_constraints as! [NSLayoutConstraint]
+        let constraints = view.constraints
         
         XCTAssertEqual(constraints[0].firstAttribute, NSLayoutAttribute.Width, "Should be width")
         XCTAssertEqual(constraints[1].firstAttribute, NSLayoutAttribute.Height, "Should be height")
@@ -254,11 +240,11 @@ class SnapKitTests: XCTestCase {
         let view = View()
         self.container.addSubview(view)
         
-        view.snp_makeConstraints { (make) -> Void in
-            make.top.equalTo(self.container.snp_top).labeled(identifier)
+        view.makeConstraints { (make) -> Void in
+            make.top.equalTo(self.container.top).labeled(identifier)
         }
         
-        let constraints = container.snp_constraints as! [NSLayoutConstraint]
+        let constraints = container.constraints
         XCTAssertEqual(constraints[0].identifier, identifier, "Identifier should be 'Test'")
     }
     


### PR DESCRIPTION
Swift should use static dispatch for methods, properties and functions that use features not available in objc, instead for categories of objc types and methods that are @objc (will use dynamic dispatch) we can use `@objc(snp_method) func method()` to make sure we don't override private APIs

Would you consider this Breaking change? It looks like useless to use prefixes in swift extension [except  some cases](https://pspdfkit.com/blog/2016/surprises-with-swift-extensions/) where @objc(prefix_name) can be used