### PR TITLE
Added convenient super view methods to ConstraintDescriptionRelatable

### DIFF
--- a/Source/ConstraintDescription.swift
+++ b/Source/ConstraintDescription.swift
@@ -95,6 +95,7 @@ public protocol ConstraintDescriptionRelatable: class {
     
     func equalTo(other: ConstraintItem) -> ConstraintDescriptionEditable
     func equalTo(other: View) -> ConstraintDescriptionEditable
+    func equalToSuperview() -> ConstraintDescriptionEditable
     @available(iOS 7.0, *)
     func equalTo(other: LayoutSupport) -> ConstraintDescriptionEditable
     @available(iOS 9.0, OSX 10.11, *)
@@ -110,6 +111,7 @@ public protocol ConstraintDescriptionRelatable: class {
     
     func lessThanOrEqualTo(other: ConstraintItem) -> ConstraintDescriptionEditable
     func lessThanOrEqualTo(other: View) -> ConstraintDescriptionEditable
+    func lessThanOrEqualToSuperview() -> ConstraintDescriptionEditable
     @available(iOS 7.0, *)
     func lessThanOrEqualTo(other: LayoutSupport) -> ConstraintDescriptionEditable
     @available(iOS 9.0, OSX 10.11, *)
@@ -125,6 +127,7 @@ public protocol ConstraintDescriptionRelatable: class {
     
     func greaterThanOrEqualTo(other: ConstraintItem) -> ConstraintDescriptionEditable
     func greaterThanOrEqualTo(other: View) -> ConstraintDescriptionEditable
+    func greaterThanOrEqualToSuperview() -> ConstraintDescriptionEditable
     @available(iOS 7.0, *)
     func greaterThanOrEqualTo(other: LayoutSupport) -> ConstraintDescriptionEditable
     @available(iOS 9.0, OSX 10.11, *)
@@ -229,6 +232,13 @@ internal class ConstraintDescription: ConstraintDescriptionExtendable, Constrain
     internal func equalTo(other: View) -> ConstraintDescriptionEditable {
         return self.constrainTo(other, relation: .Equal)
     }
+    internal func equalToSuperview() -> ConstraintDescriptionEditable {
+        guard let superview = fromItem.view?.superview else {
+            fatalError("equalToSuperview() requires the view have a superview before being set.")
+        }
+        
+        return self.equalTo(superview)
+    }
     @available(iOS 7.0, *)
     internal func equalTo(other: LayoutSupport) -> ConstraintDescriptionEditable {
         return self.constrainTo(other, relation: .Equal)
@@ -270,6 +280,13 @@ internal class ConstraintDescription: ConstraintDescriptionExtendable, Constrain
     internal func lessThanOrEqualTo(other: View) -> ConstraintDescriptionEditable {
         return self.constrainTo(other, relation: .LessThanOrEqualTo)
     }
+    internal func lessThanOrEqualToSuperview() -> ConstraintDescriptionEditable {
+        guard let superview = fromItem.view?.superview else {
+            fatalError("lessThanOrEqualToSuperview() requires the view have a superview before being set.")
+        }
+        
+        return self.lessThanOrEqualTo(superview)
+    }
     @available(iOS 7.0, *)
     internal func lessThanOrEqualTo(other: LayoutSupport) -> ConstraintDescriptionEditable {
         return self.constrainTo(other, relation: .LessThanOrEqualTo)
@@ -310,6 +327,13 @@ internal class ConstraintDescription: ConstraintDescriptionExtendable, Constrain
     }
     internal func greaterThanOrEqualTo(other: View) -> ConstraintDescriptionEditable {
         return self.constrainTo(other, relation: .GreaterThanOrEqualTo)
+    }
+    internal func greaterThanOrEqualToSuperview() ->  ConstraintDescriptionEditable {
+        guard let superview = fromItem.view?.superview else {
+            fatalError("greaterThanOrEqualToSuperview() requires the view have a superview before being set.")
+        }
+        
+        return self.greaterThanOrEqualTo(superview)
     }
     @available(iOS 7.0, *)
     internal func greaterThanOrEqualTo(other: LayoutSupport) -> ConstraintDescriptionEditable {

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -262,4 +262,33 @@ class SnapKitTests: XCTestCase {
         XCTAssertEqual(constraints[0].identifier, identifier, "Identifier should be 'Test'")
     }
     
+    func testSuperviewConstraints() {
+        let view = View()
+        
+        container.addSubview(view)
+        
+        view.snp_makeConstraints { (make) -> Void in
+            make.top.equalToSuperview().inset(10)
+            make.bottom.equalToSuperview().inset(10)
+        }
+        
+        XCTAssertEqual(container.snp_constraints.count, 2, "Should have 2 constraints")
+        
+        let constraints = container.snp_constraints as! [NSLayoutConstraint]
+        
+        XCTAssertEqual(constraints[0].firstAttribute, NSLayoutAttribute.Top, "Should be top")
+        XCTAssertEqual(constraints[1].firstAttribute, NSLayoutAttribute.Bottom, "Should be bottom")
+        
+        XCTAssertEqual(constraints[0].secondAttribute, NSLayoutAttribute.Top, "Should be top")
+        XCTAssertEqual(constraints[1].secondAttribute, NSLayoutAttribute.Bottom, "Should be bottom")
+        
+        XCTAssertEqual(constraints[0].firstItem as? UIView, view, "Should be added subview")
+        XCTAssertEqual(constraints[1].firstItem as? UIView, view, "Should be added subview")
+        
+        XCTAssertEqual(constraints[0].secondItem as? UIView, container, "Should be containerView")
+        XCTAssertEqual(constraints[1].secondItem as? UIView, container, "Should be containerView")
+        
+        XCTAssertEqual(constraints[0].constant, 10, "Should be 10")
+        XCTAssertEqual(constraints[1].constant, -10, "Should be 10")
+    }
 }


### PR DESCRIPTION
This feature would be wonderful if added. You no longer need to keep track of what the superview is and no longer need to `make.leading.equalTo(self.superview!)`. Now all you would need to do is `make.leading.equalToSuperview()` There is also a fatal error thrown if the view has no superview.