### PR TITLE
Exposes "native constraints"

### DIFF
--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -58,7 +58,7 @@ public class Constraint {
     public func updatePriorityMedium() -> Void { fatalError("Must be implemented by Concrete subclass.") }
     public func updatePriorityLow() -> Void { fatalError("Must be implemented by Concrete subclass.") }
 
-    public func nativeConstraints() -> [LayoutConstraint] { fatalError("Must be implemented by Concrete subclass.") }
+    public var layoutConstraints: [LayoutConstraint] { fatalError("Must be implemented by Concrete subclass.") }
     
     internal var makerFile: String = "Unknown"
     internal var makerLine: UInt = 0
@@ -199,7 +199,7 @@ internal class ConcreteConstraint: Constraint {
     
     private var installInfo: ConcreteConstraintInstallInfo? = nil
     
-    internal override func nativeConstraints() -> [LayoutConstraint] {
+    override var layoutConstraints: [LayoutConstraint] {
         if installInfo == nil {
             install()
         }

--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -57,6 +57,8 @@ public class Constraint {
     public func updatePriorityHigh() -> Void { fatalError("Must be implemented by Concrete subclass.") }
     public func updatePriorityMedium() -> Void { fatalError("Must be implemented by Concrete subclass.") }
     public func updatePriorityLow() -> Void { fatalError("Must be implemented by Concrete subclass.") }
+
+    public func nativeConstraints() -> [LayoutConstraint] { fatalError("Must be implemented by Concrete subclass.") }
     
     internal var makerFile: String = "Unknown"
     internal var makerLine: UInt = 0
@@ -197,6 +199,17 @@ internal class ConcreteConstraint: Constraint {
     
     private var installInfo: ConcreteConstraintInstallInfo? = nil
     
+    internal override func nativeConstraints() -> [LayoutConstraint] {
+        if installInfo == nil {
+            install()
+        }
+        
+        guard let installInfo = installInfo else {
+            return []
+        }
+        return installInfo.layoutConstraints.allObjects as! [LayoutConstraint]
+    }
+
     internal init(fromItem: ConstraintItem, toItem: ConstraintItem, relation: ConstraintRelation, constant: Any, multiplier: Float, priority: Float, label: String? = nil) {
         self.fromItem = fromItem
         self.toItem = toItem

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -291,4 +291,27 @@ class SnapKitTests: XCTestCase {
         XCTAssertEqual(constraints[0].constant, 10, "Should be 10")
         XCTAssertEqual(constraints[1].constant, -10, "Should be 10")
     }
+
+    func testNativeConstraints() {
+        let view = View()
+        
+        container.addSubview(view)
+        
+        var topNativeConstraints: [LayoutConstraint]!
+        var topNativeConstraint: LayoutConstraint?
+        var sizeNativeConstraints: [LayoutConstraint]!
+        view.snp_makeConstraints { (make) -> Void in
+            let topConstraint = make.top.equalToSuperview().inset(10).constraint
+            topNativeConstraints = topConstraint.nativeConstraints()
+            topNativeConstraint = topConstraint.nativeConstraints().first
+            let sizeConstraints = make.size.equalTo(50).constraint
+            sizeNativeConstraints = sizeConstraints.nativeConstraints()
+        }
+
+        XCTAssertEqual(topNativeConstraints.count, 1, "make.top should creates one native constraint")
+        XCTAssertEqual(topNativeConstraint?.constant, 10, "topNativeConstraint.constant is set to 10")
+        XCTAssertEqual(sizeNativeConstraints.count, 2, "make.tosize should create two native constraint")
+        XCTAssertEqual(sizeNativeConstraints[0].constant, 50, "sizeNativeConstraints should set size[0] to 50")
+        XCTAssertEqual(sizeNativeConstraints[1].constant, 50, "sizeNativeConstraints should set size[1] to 50")
+    }
 }

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -302,10 +302,10 @@ class SnapKitTests: XCTestCase {
         var sizeNativeConstraints: [LayoutConstraint]!
         view.snp_makeConstraints { (make) -> Void in
             let topConstraint = make.top.equalToSuperview().inset(10).constraint
-            topNativeConstraints = topConstraint.nativeConstraints()
-            topNativeConstraint = topConstraint.nativeConstraints().first
+            topNativeConstraints = topConstraint.layoutConstraints
+            topNativeConstraint = topConstraint.layoutConstraints.first
             let sizeConstraints = make.size.equalTo(50).constraint
-            sizeNativeConstraints = sizeConstraints.nativeConstraints()
+            sizeNativeConstraints = sizeConstraints.layoutConstraints
         }
 
         XCTAssertEqual(topNativeConstraints.count, 1, "make.top should creates one native constraint")


### PR DESCRIPTION
This is a minimally invasive attempt to expose the `LayoutConstraint` objects that SnapKit creates, and is a solve for #241.

When `nativeConstraints()` is called on `ConcreteConstraint`, it first checks to see if the constraint(s) have been installed, and calls `install()` if `installInfo == nil`.  I checked this for sanity by looking at how often `install()` is called already, and it looked like it was written in such a way that it can be called more than once; in the spec code, it *is* called more than once on many of the constraints.  So hopefully this is an 👌 thing to do.

The spec code just does a few sanity checks: how many constraints are created, and do they have the expected `constant` values.