### PR TITLE
Add support for Swift 2.3

### DIFF
--- a/SnapKit.xcodeproj/project.pbxproj
+++ b/SnapKit.xcodeproj/project.pbxproj
@@ -463,9 +463,11 @@
 					};
 					EEBCC9D719CC627D0083B827 = {
 						CreatedOnToolsVersion = 6.0;
+						LastSwiftMigration = 0800;
 					};
 					EEBCC9E119CC627D0083B827 = {
 						CreatedOnToolsVersion = 6.0;
+						LastSwiftMigration = 0800;
 					};
 					EECDB3791AC0C9D4006BBC11 = {
 						CreatedOnToolsVersion = 6.2;
@@ -882,6 +884,7 @@
 				PRODUCT_NAME = SnapKit;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SWIFT_VERSION = 2.3;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -903,6 +906,7 @@
 				PRODUCT_NAME = SnapKit;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SWIFT_VERSION = 2.3;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -916,6 +920,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.snapkit.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -927,6 +932,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.snapkit.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/Source/ConstraintAttributes.swift
+++ b/Source/ConstraintAttributes.swift
@@ -130,7 +130,11 @@ internal struct ConstraintAttributes: OptionSetType, BooleanType {
             attrs.append(.CenterY)
         }
         if (self.contains(ConstraintAttributes.Baseline)) {
+            #if swift(>=2.3)
+            attrs.append(.LastBaseline)
+            #else
             attrs.append(.Baseline)
+            #endif
         }
         
         #if os(iOS) || os(tvOS)


### PR DESCRIPTION
This updates the code to work under both 2.2 and 2.3 while developers handle their transition period up to Swift 3. The project file is also updated to indicate the last migration, and the version of swift. The version instructs Xcode 8 which internal toolchain is to be used.