### PR TITLE
Make the ConstrainMaker view property public

### DIFF
--- a/Source/ConstraintMaker.swift
+++ b/Source/ConstraintMaker.swift
@@ -126,7 +126,7 @@ public class ConstraintMaker {
     
     internal let file: String
     internal let line: UInt
-    internal let view: View
+    public let view: View
     internal var constraintDescriptions = [ConstraintDescription]()
     
     internal func makeConstraintDescription(attributes: ConstraintAttributes) -> ConstraintDescription {


### PR DESCRIPTION
Making the view public would allow common layout patterns to be reused.

```
func snapToEdges(make: ConstraintMaker) {
    guard let superview = make.view.superview else { return }
    make.edges.equalTo(superview)
}
numberLabel.snp_makeConstraints(closure: snapToEdges)
otherLabel.snp_makeConstraints(closure: snapToEdges)
```