### PR TITLE
Fix various issues with legacy support in 0.40.0

### DIFF
--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -220,14 +220,14 @@ public class Constraint {
         }
         
         guard let installedLayoutConstraints = self.installInfo?.layoutConstraints.allObjects as? [LayoutConstraint]
-              where installedLayoutConstraints.count > 0 else {
-            return
+            where installedLayoutConstraints.count > 0 else {
+                return
         }
         
         #if SNAPKIT_DEPLOYMENT_LEGACY && !os(OSX)
             if #available(iOS 8.0, *) {
-                NSLayoutConstraint.deactivateConstraints(installedLayoutConstraints)
-            } else if let installedOnView = installInfo.view {
+                NSLayoutConstraint.deactivate(installedLayoutConstraints)
+            } else if let installedOnView = installInfo?.view {
                 installedOnView.removeConstraints(installedLayoutConstraints)
             }
         #else

--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -240,12 +240,12 @@ public class Constraint {
     
     internal func activateIfNeeded() {
         guard self.installInfo != nil else {
-            let _ = self.installIfNeeded()
+            _ = self.installIfNeeded()
             return
         }
         #if SNAPKIT_DEPLOYMENT_LEGACY
             guard #available(iOS 8.0, OSX 10.10, *) else {
-                self.installIfNeeded()
+                _ = self.installIfNeeded()
                 return
             }
         #endif

--- a/Source/ConstraintView+Extensions.swift
+++ b/Source/ConstraintView+Extensions.swift
@@ -63,30 +63,39 @@ public extension ConstraintView {
     @available(*, deprecated:0.30.0, message:"Please use newer snp.* syntax.")
     public var snp_baseline: ConstraintItem { return self.snp.baseline }
     
+    @available(iOS 8.0, *)
     @available(iOS, deprecated:0.30.0, message:"Please use newer snp.* syntax.")
     public var snp_firstBaseline: ConstraintItem { return self.snp.firstBaseline }
     
+    @available(iOS 8.0, *)
     @available(iOS, deprecated:0.30.0, message:"Please use newer snp.* syntax.")
     public var snp_leftMargin: ConstraintItem { return self.snp.leftMargin }
     
+    @available(iOS 8.0, *)
     @available(iOS, deprecated:0.30.0, message:"Please use newer snp.* syntax.")
     public var snp_topMargin: ConstraintItem { return self.snp.topMargin }
     
+    @available(iOS 8.0, *)
     @available(iOS, deprecated:0.30.0, message:"Please use newer snp.* syntax.")
     public var snp_rightMargin: ConstraintItem { return self.snp.rightMargin }
     
+    @available(iOS 8.0, *)
     @available(iOS, deprecated:0.30.0, message:"Please use newer snp.* syntax.")
     public var snp_bottomMargin: ConstraintItem { return self.snp.bottomMargin }
     
+    @available(iOS 8.0, *)
     @available(iOS, deprecated:0.30.0, message:"Please use newer snp.* syntax.")
     public var snp_leadingMargin: ConstraintItem { return self.snp.leadingMargin }
     
+    @available(iOS 8.0, *)
     @available(iOS, deprecated:0.30.0, message:"Please use newer snp.* syntax.")
     public var snp_trailingMargin: ConstraintItem { return self.snp.trailingMargin }
     
+    @available(iOS 8.0, *)
     @available(iOS, deprecated:0.30.0, message:"Please use newer snp.* syntax.")
     public var snp_centerXWithinMargins: ConstraintItem { return self.snp.centerXWithinMargins }
     
+    @available(iOS 8.0, *)
     @available(iOS, deprecated:0.30.0, message:"Please use newer snp.* syntax.")
     public var snp_centerYWithinMargins: ConstraintItem { return self.snp.centerYWithinMargins }
     
@@ -99,9 +108,11 @@ public extension ConstraintView {
     @available(*, deprecated:0.30.0, message:"Please use newer snp.* syntax.")
     public var snp_center: ConstraintItem { return self.snp.center }
     
+    @available(iOS 8.0, *)
     @available(iOS, deprecated:0.30.0, message:"Please use newer snp.* syntax.")
     public var snp_margins: ConstraintItem { return self.snp.margins }
     
+    @available(iOS 8.0, *)
     @available(iOS, deprecated:0.30.0, message:"Please use newer snp.* syntax.")
     public var snp_centerWithinMargins: ConstraintItem { return self.snp.centerWithinMargins }
     


### PR DESCRIPTION
Working on a project that has iOS 7 as deployment target. This seems to be the way to say that something is only available for iOS 8. I didn't have an iOS 8 project immediately available but if you wrap access to these properties in the following, then it still says deprecated. 

```
if #available(iOS 8.0, *) {

}