### PR TITLE
support NSView layer-backed view animation

### DIFF
--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -220,7 +220,7 @@ internal class ConcreteConstraint: Constraint {
         self.label = label
     }
     
-    internal func installOnView(updateExisting updateExisting: Bool = false, file: String? = nil, line: UInt? = nil) -> [LayoutConstraint] {
+    internal func installOnView(updateExisting updateExisting: Bool = false, forAnimator: Bool = false, file: String? = nil, line: UInt? = nil) -> [LayoutConstraint] {
         var installOnView: View? = nil
         if self.toItem.view != nil {
             installOnView = closestCommonSuperviewFromView(self.fromItem.view, toView: self.toItem.view)
@@ -319,7 +319,16 @@ internal class ConcreteConstraint: Constraint {
                 
                 // if we have existing one lets just update the constant
                 if updateLayoutConstraint != nil {
-                    updateLayoutConstraint!.constant = layoutConstraint.constant
+                    #if os(OSX)
+                        if forAnimator {
+                            updateLayoutConstraint!.animator().constant = layoutConstraint.constant
+                        }else {
+                            updateLayoutConstraint!.constant = layoutConstraint.constant
+                        }
+                    #else
+                        updateLayoutConstraint!.constant = layoutConstraint.constant
+                    #endif
+                    
                 }
                     // otherwise add this layout constraint to new keep list
                 else {

--- a/Source/ConstraintMaker.swift
+++ b/Source/ConstraintMaker.swift
@@ -188,6 +188,19 @@ public class ConstraintMaker {
         }
     }
     
+    internal class func updateAnimatorConstraints(view view: View, file: String = "Unknown", line: UInt = 0, @noescape closure: (make: ConstraintMaker) -> Void) {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        let maker = ConstraintMaker(view: view, file: file, line: line)
+        closure(make: maker)
+        
+        let constraints = maker.constraintDescriptions.map{ $0.constraint as! ConcreteConstraint}
+        for constraint in constraints {
+            constraint.makerFile = maker.file
+            constraint.makerLine = maker.line
+            constraint.installOnView(updateExisting: true, forAnimator: true)
+        }
+    }
+    
     internal class func removeConstraints(view view: View) {
         for existingLayoutConstraint in view.snp_installedLayoutConstraints {
             existingLayoutConstraint.snp_constraint?.uninstall()

--- a/Source/View+SnapKit.swift
+++ b/Source/View+SnapKit.swift
@@ -152,6 +152,19 @@ public extension View {
     }
     
     /**
+        Updates constraints's proxy of animator with a `ConstraintMaker` that will only replace existing constraints that match.
+        New constraints only be installed but no animate.
+     
+        For constraints to match only the constant can be updated.
+     
+        - parameter closure that will be passed the `ConstraintMaker` to update the constraints with
+    */
+    @available(OSX 10.5, *)
+    public func snp_updateAnimatorConstraints(file: String = #file, line: UInt = #line, @noescape closure: (make: ConstraintMaker) -> Void) -> Void {
+        ConstraintMaker.updateAnimatorConstraints(view: self, file: file, line: line, closure: closure)
+    }
+    
+    /**
         Remakes constraints with a `ConstraintMaker` that will first remove all previously made constraints and make and install new ones.
     
         - parameter closure that will be passed the `ConstraintMaker` to remake the constraints with

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -89,6 +89,12 @@ class SnapKitTests: XCTestCase {
         
         XCTAssertEqual(self.container.snp_constraints.count, 2, "Should still have 2 constraints installed")
         
+        v1.snp_updateAnimatorConstraints { (make) -> Void in
+            make.top.equalTo(v2.snp_top).offset(20)
+            return
+        }
+        
+        XCTAssertEqual(self.container.snp_constraints.count, 2, "Should still have 2 constraints installed")
     }
     
     func testRemakeConstraints() {


### PR DESCRIPTION
add a new api on updateConstraints for layer-backed view animation

so you can write like this:

``` swift
NSAnimationContext.runAnimationGroup({ (context) in
                    context.duration = 1.0
                    self.view.snp_updateAnimatorConstraints(closure: { (make) in
                        make.width.equalTo(50.0)
                    })
                }, completionHandler: nil)  
```
