### PR TITLE
Add snp_alignEdges for quick edge alignment of views

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,5 +1,6 @@
 ### New Issue Checklist
 
+* [x] I accept that if I do not fill out this issue template my issue will be immediately closed with no response
 * [ ] I have looked at the [Documentation](http://snapkit.io/docs)
 * [ ] I have read the [F.A.Q.](http://snapkit.io/faq)
 

--- a/Source/View+SnapKit.swift
+++ b/Source/View+SnapKit.swift
@@ -167,6 +167,17 @@ public extension View {
         ConstraintMaker.removeConstraints(view: self)
     }
     
+    /**
+     Makes edge constraints with a `ConstraintMaker` to align view edges, and installs them along side any previous made constraints.
+     
+     - parameter secondView whose edges will be aligned with the first view
+     */
+    public func snp_alignEdges(file: String = #file, line: UInt = #line, secondView: View) {
+        ConstraintMaker.makeConstraints(view: self, file: file, line: line) { (make) in
+            make.edges.equalTo(secondView)
+        }
+    }
+    
     internal var snp_installedLayoutConstraints: [LayoutConstraint] {
         get {
             if let constraints = objc_getAssociatedObject(self, &installedLayoutConstraintsKey) as? [LayoutConstraint] {

--- a/Source/View+SnapKit.swift
+++ b/Source/View+SnapKit.swift
@@ -172,9 +172,9 @@ public extension View {
      
      - parameter secondView whose edges will be aligned with the first view
      */
-    public func snp_alignEdges(file: String = #file, line: UInt = #line, secondView: View) {
+    public func snp_alignEdges(file: String = #file, line: UInt = #line, other: View) {
         ConstraintMaker.makeConstraints(view: self, file: file, line: line) { (make) in
-            make.edges.equalTo(secondView)
+            make.edges.equalTo(other)
         }
     }
     


### PR DESCRIPTION
This allows for faster edge alignment because rather than using
```
view.snp_makeConstraints { (make) in
    make.edges.equalTo(superview)
}
```
users can use
```
view.snp_alignEdges(secondView: superview)
```