### PR TITLE
fixbug: store constraint issue

### DIFF
--- a/Source/ConstraintDescription.swift
+++ b/Source/ConstraintDescription.swift
@@ -40,24 +40,26 @@ public class ConstraintDescription {
     internal var constant: ConstraintConstantTarget = 0.0
     internal var priority: ConstraintPriorityTarget = 1000.0
     internal var constraint: Constraint? {
-        guard let relation = self.relation,
-              let related = self.related,
-              let sourceLocation = self.sourceLocation else {
-            return nil
+        if internalConstraint == nil {
+            guard let relation = self.relation,
+                let related = self.related,
+                let sourceLocation = self.sourceLocation else {
+                    return nil
+            }
+            let from = ConstraintItem(target: self.view, attributes: self.attributes)
+            
+            internalConstraint = Constraint(from: from,
+                                            to: related,
+                                            relation: relation,
+                                            sourceLocation: sourceLocation,
+                                            label: self.label,
+                                            multiplier: self.multiplier,
+                                            constant: self.constant,
+                                            priority: self.priority)
         }
-        let from = ConstraintItem(target: self.view, attributes: self.attributes)
-        
-        return Constraint(
-            from: from,
-            to: related,
-            relation: relation,
-            sourceLocation: sourceLocation,
-            label: self.label,
-            multiplier: self.multiplier,
-            constant: self.constant,
-            priority: self.priority
-        )
+        return internalConstraint
     }
+    private var internalConstraint: Constraint?
     
     // MARK: Initialization
     


### PR DESCRIPTION
* branch: feature/0.40.0

Hi, there's some trouble with store constraint.

when I write:
```
let storedConstraint: Constraint? = nil
someView.snp.makeConstraint({ (make) in
       // ConstraintDescription will create a constraint and store it to `constraint.layoutConstraints`
        storedConstraint = make.someConstraint.equalTo(someValue).constraint
})
//when execute this closure, constraint will be created **again**
// ...some other code

storedConstraint.deactivate()   // this may do nothing, because storedConstraint may not hold the truely layoutConstraint

someView.snp.make.Constraint({ (make) in 
        // some new constraints setting
})
```