### PR TITLE
Fixed landscape layout for redView and fixed typo in Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,4 +8,4 @@ We gladly accept any PR's assuming they are well written, documented ( if necess
 
 Please use the issue tracker *strictly* for bugs you think are caused by a code issue in SnapKit. We’re very busy and as a free open source library do not have the time to adequately help with questions that are more tutorial/training in nature and recommend using Stack Overflow and Google as alternatives.
 
-Please do not be offended if we close your issue and reference this document. If you believe the issue is truely a fault in SnapKit’s codebase re-open it.
+Please do not be offended if we close your issue and reference this document. If you believe the issue is truly a fault in SnapKit’s codebase re-open it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,4 +8,4 @@ We gladly accept any PR's assuming they are well written, documented ( if necess
 
 Please use the issue tracker *strictly* for bugs you think are caused by a code issue in SnapKit. We’re very busy and as a free open source library do not have the time to adequately help with questions that are more tutorial/training in nature and recommend using Stack Overflow and Google as alternatives.
 
-Please do not be offended if we close your issue and reference this document. If you believe the issue is truly a fault in SnapKit’s codebase re-open it.
+Please do not be offended if we close your issue and reference this document. If you believe the issue is truly a fault in SnapKit’s codebase, re-open it.

--- a/Example-iOS/demos/SimpleLayoutViewController.swift
+++ b/Example-iOS/demos/SimpleLayoutViewController.swift
@@ -67,7 +67,7 @@ class SimpleLayoutViewController: UIViewController {
 
             redView.snp_makeConstraints { make in
                 make.top.equalTo(blackView.snp_bottom).offset(20.0)
-                make.left.equalTo(20.0)
+                make.right.equalTo(blackView.snp_left).offset(-20.0)
                 make.size.equalTo(CGSizeMake(100.0, 100.0))
             }
 


### PR DESCRIPTION
I was playing around with the example app and the redView was not aligned correctly. I fixed it so it's properly laid out like the other views.

I also edited the typo in the contributing file! 