### PR TITLE
fix "Mutating a priority from required to not on an installed constra…

### DIFF
--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -232,7 +232,7 @@ public class Constraint {
             #if os(iOS)
                 let requiredPriority: UILayoutPriority = UILayoutPriorityRequired
             #else
-                let requiredPriority: UILayoutPriority = 1000.0
+                let requiredPriority: Float = 1000.0
             #endif
             
             

--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -229,11 +229,9 @@ public class Constraint {
             let attribute = (layoutConstraint.secondAttribute == .notAnAttribute) ? layoutConstraint.firstAttribute : layoutConstraint.secondAttribute
             layoutConstraint.constant = self.constant.constraintConstantTargetValueFor(layoutAttribute: attribute)
             
-            guard (layoutConstraint.priority < UILayoutPriorityRequired), (self.priority.constraintPriorityTargetValue != UILayoutPriorityRequired) else {
-                fatalError("Mutating a priority from required to not on an installed constraint (or vice-versa) is not supported.")
+            if (layoutConstraint.priority < UILayoutPriorityRequired), (self.priority.constraintPriorityTargetValue != UILayoutPriorityRequired) {
+                layoutConstraint.priority = self.priority.constraintPriorityTargetValue
             }
-
-            layoutConstraint.priority = self.priority.constraintPriorityTargetValue            
         }
     }
     

--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -229,10 +229,11 @@ public class Constraint {
             let attribute = (layoutConstraint.secondAttribute == .notAnAttribute) ? layoutConstraint.firstAttribute : layoutConstraint.secondAttribute
             layoutConstraint.constant = self.constant.constraintConstantTargetValueFor(layoutAttribute: attribute)
             
-            if (layoutConstraint.priority != self.priority.constraintPriorityTargetValue) {
-                layoutConstraint.priority = self.priority.constraintPriorityTargetValue
+            guard (layoutConstraint.priority < UILayoutPriorityRequired), (self.priority.constraintPriorityTargetValue != UILayoutPriorityRequired) else {
+                fatalError("Mutating a priority from required to not on an installed constraint (or vice-versa) is not supported.")
             }
-            
+
+            layoutConstraint.priority = self.priority.constraintPriorityTargetValue            
         }
     }
     

--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -228,7 +228,11 @@ public class Constraint {
         for layoutConstraint in self.layoutConstraints {
             let attribute = (layoutConstraint.secondAttribute == .notAnAttribute) ? layoutConstraint.firstAttribute : layoutConstraint.secondAttribute
             layoutConstraint.constant = self.constant.constraintConstantTargetValueFor(layoutAttribute: attribute)
-            layoutConstraint.priority = self.priority.constraintPriorityTargetValue
+            
+            if (layoutConstraint.priority != self.priority.constraintPriorityTargetValue) {
+                layoutConstraint.priority = self.priority.constraintPriorityTargetValue
+            }
+            
         }
     }
     

--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -229,7 +229,7 @@ public class Constraint {
             let attribute = (layoutConstraint.secondAttribute == .notAnAttribute) ? layoutConstraint.firstAttribute : layoutConstraint.secondAttribute
             layoutConstraint.constant = self.constant.constraintConstantTargetValueFor(layoutAttribute: attribute)
             
-            #if os(iOS)
+            #if os(iOS) || os(tvOS)
                 let requiredPriority: UILayoutPriority = UILayoutPriorityRequired
             #else
                 let requiredPriority: Float = 1000.0

--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -229,7 +229,14 @@ public class Constraint {
             let attribute = (layoutConstraint.secondAttribute == .notAnAttribute) ? layoutConstraint.firstAttribute : layoutConstraint.secondAttribute
             layoutConstraint.constant = self.constant.constraintConstantTargetValueFor(layoutAttribute: attribute)
             
-            if (layoutConstraint.priority < UILayoutPriorityRequired), (self.priority.constraintPriorityTargetValue != UILayoutPriorityRequired) {
+            #if os(iOS)
+                let requiredPriority: UILayoutPriority = UILayoutPriorityRequired
+            #else
+                let requiredPriority: UILayoutPriority = 1000.0
+            #endif
+            
+            
+            if (layoutConstraint.priority < requiredPriority), (self.priority.constraintPriorityTargetValue != requiredPriority) {
                 layoutConstraint.priority = self.priority.constraintPriorityTargetValue
             }
         }


### PR DESCRIPTION
on iOS 8, SnapKit crash with 

*** Assertion failure in -[SnapKit.LayoutConstraint setPriority:], /SourceCache/Foundation_Sim/Foundation-1144.17/Layout.subproj/NSLayoutConstraint.m:174

*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Mutating a priority from required to not on an installed constraint (or vice-versa) is not supported.  You passed priority 1000 and the existing priority was 1000.'

when calling updateOffset(amount:)