### PR TITLE
Added convenience methods to ConstraintMakerRelatable for superview access

### DIFF
--- a/Source/ConstraintMakerRelatable.swift
+++ b/Source/ConstraintMakerRelatable.swift
@@ -88,8 +88,23 @@ public class ConstraintMakerRelatable {
     }
     
     @discardableResult
+    public func lessThanOrEqualToSuperview(_ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
+        guard let other = self.description.view.superview else {
+            fatalError("Expected superview but found nil when attempting make constraint `lessThanOrEqualToSuperview`.")
+        }
+        return self.relatedTo(other, relation: .lessThanOrEqual, file: file, line: line)
+    }
+    
+    @discardableResult
     public func greaterThanOrEqualTo(_ other: ConstraintRelatableTarget, _ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
         return self.relatedTo(other, relation: .greaterThanOrEqual, file: file, line: line)
     }
     
+    @discardableResult
+    public func greaterThanOrEqualToSuperview(_ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
+        guard let other = self.description.view.superview else {
+            fatalError("Expected superview but found nil when attempting make constraint `greaterThanOrEqualToSuperview`.")
+        }
+        return self.relatedTo(other, relation: .greaterThanOrEqual, file: file, line: line)
+    }
 }


### PR DESCRIPTION
Added two new convenience methods to ConstraintMakerRelatable for superview access
`greaterThanOrEqualToSuperview`
`lessThanOrEqualToSuperview`

As mentioned in the issue #294 