### PR TITLE
add @available to ConstraintLayoutGuide extension

### DIFF
--- a/Source/LayoutConstraintItem.swift
+++ b/Source/LayoutConstraintItem.swift
@@ -31,6 +31,7 @@
 public protocol LayoutConstraintItem: class {
 }
 
+@available(iOSApplicationExtension 9.0, *)
 extension ConstraintLayoutGuide : LayoutConstraintItem {
 }
 

--- a/Source/LayoutConstraintItem.swift
+++ b/Source/LayoutConstraintItem.swift
@@ -31,7 +31,7 @@
 public protocol LayoutConstraintItem: class {
 }
 
-@available(iOSApplicationExtension 9.0, *)
+@available(iOS 9.0, *)
 extension ConstraintLayoutGuide : LayoutConstraintItem {
 }
 

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -62,26 +62,31 @@ class SnapKitTests: XCTestCase {
     
     func testGuideMakeConstraints() {
         let v1 = View()
-        let g1 = UILayoutGuide()
-        
-        self.container.addSubview(v1)
-        self.container.addLayoutGuide(g1)
-        
-        v1.snp.makeConstraints { (make) -> Void in
-            make.top.equalTo(g1.snp.top).offset(50)
-            make.left.equalTo(g1.snp.top).offset(50)
-            return
+        if #available(iOS 9.0, *) {
+            let g1 = UILayoutGuide()
+            self.container.addSubview(v1)
+            self.container.addLayoutGuide(g1)
+            
+            v1.snp.makeConstraints { (make) -> Void in
+                make.top.equalTo(g1.snp.top).offset(50)
+                make.left.equalTo(g1.snp.top).offset(50)
+                return
+            }
+            
+            XCTAssertEqual(self.container.snp_constraints.count, 2, "Should have 2 constraints installed")
+            
+            g1.snp.makeConstraints { (make) -> Void in
+                make.edges.equalTo(v1)
+                return
+            }
+            
+            XCTAssertEqual(self.container.snp_constraints.count, 6, "Should have 6 constraints installed")
+
+        } else {
+            XCTAssertTrue(true)
         }
         
-        XCTAssertEqual(self.container.snp_constraints.count, 2, "Should have 2 constraints installed")
-        
-        g1.snp.makeConstraints { (make) -> Void in
-            make.edges.equalTo(v1)
-            return
-        }
-        
-        XCTAssertEqual(self.container.snp_constraints.count, 6, "Should have 6 constraints installed")
-    }
+            }
     
     func testMakeImpliedSuperviewConstraints() {
         let v1 = View()


### PR DESCRIPTION
It seems that without @available(iOSApplicationExtension 9.0, *) above the ConstraintLayoutGuide extension the instance of ConstraintLayoutGuide have no member named "makeConstraints".

I use SnapKit in latest release XCode8 and swift3