### PR TITLE
Fix tests on macOS

### DIFF
--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -59,35 +59,32 @@ class SnapKitTests: XCTestCase {
         XCTAssertEqual(self.container.snp_constraints.count, 6, "Should have 6 constraints installed")
         
     }
-    
-    func testGuideMakeConstraints() {
-        let v1 = View()
-        if #available(iOS 9.0, *) {
-            let g1 = UILayoutGuide()
-            self.container.addSubview(v1)
-            self.container.addLayoutGuide(g1)
-            
-            v1.snp.makeConstraints { (make) -> Void in
-                make.top.equalTo(g1.snp.top).offset(50)
-                make.left.equalTo(g1.snp.top).offset(50)
-                return
-            }
-            
-            XCTAssertEqual(self.container.snp_constraints.count, 2, "Should have 2 constraints installed")
-            
-            g1.snp.makeConstraints { (make) -> Void in
-                make.edges.equalTo(v1)
-                return
-            }
-            
-            XCTAssertEqual(self.container.snp_constraints.count, 6, "Should have 6 constraints installed")
 
-        } else {
-            XCTAssertTrue(true)
+    #if os(iOS) || os(tvOS)
+    func testGuideMakeConstraints() {
+        guard #available(iOS 9.0, *) else { return }
+        let v1 = View()
+        let g1 = UILayoutGuide()
+        self.container.addSubview(v1)
+        self.container.addLayoutGuide(g1)
+        
+        v1.snp.makeConstraints { (make) -> Void in
+            make.top.equalTo(g1.snp.top).offset(50)
+            make.left.equalTo(g1.snp.top).offset(50)
+            return
         }
         
-            }
-    
+        XCTAssertEqual(self.container.snp_constraints.count, 2, "Should have 2 constraints installed")
+        
+        g1.snp.makeConstraints { (make) -> Void in
+            make.edges.equalTo(v1)
+            return
+        }
+        
+        XCTAssertEqual(self.container.snp_constraints.count, 6, "Should have 6 constraints installed")
+    }
+    #endif
+
     func testMakeImpliedSuperviewConstraints() {
         let v1 = View()
         let v2 = View()


### PR DESCRIPTION
The test for `UILayoutGuide` should only run on iOS and tvOS, so I added a preprocessor directive. Also did some cleanup to the test function.