### PR TITLE
Restores access to native constraints via 'layoutConstraints' property

### DIFF
--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -28,10 +28,10 @@
 #endif
 
 public final class Constraint {
-    
+
     internal let sourceLocation: (String, UInt)
     internal let label: String?
-    
+
     private let from: ConstraintItem
     private let to: ConstraintItem
     private let relation: ConstraintRelation
@@ -46,10 +46,10 @@ public final class Constraint {
           self.updateConstantAndPriorityIfNeeded()
         }
     }
-    private var layoutConstraints: [LayoutConstraint]
-    
+    public var layoutConstraints: [LayoutConstraint]
+
     // MARK: Initialization
-    
+
     internal init(from: ConstraintItem,
                   to: ConstraintItem,
                   relation: ConstraintRelation,
@@ -67,17 +67,17 @@ public final class Constraint {
         self.constant = constant
         self.priority = priority
         self.layoutConstraints = []
-        
+
         // get attributes
         let layoutFromAttributes = self.from.attributes.layoutAttributes
         let layoutToAttributes = self.to.attributes.layoutAttributes
-        
+
         // get layout from
         let layoutFrom = self.from.layoutConstraintItem!
-        
+
         // get relation
         let layoutRelation = self.relation.layoutRelation
-        
+
         for layoutFromAttribute in layoutFromAttributes {
             // get layout to attribute
             let layoutToAttribute: NSLayoutAttribute
@@ -130,18 +130,18 @@ public final class Constraint {
                     layoutToAttribute = layoutFromAttribute
                 }
             #endif
-            
+
             // get layout constant
             let layoutConstant: CGFloat = self.constant.constraintConstantTargetValueFor(layoutAttribute: layoutToAttribute)
-            
+
             // get layout to
             var layoutTo: AnyObject? = self.to.target
-            
+
             // use superview if possible
             if layoutTo == nil && layoutToAttribute != .width && layoutToAttribute != .height {
                 layoutTo = layoutFrom.superview
             }
-            
+
             // create layout constraint
             let layoutConstraint = LayoutConstraint(
                 item: layoutFrom,
@@ -152,119 +152,119 @@ public final class Constraint {
                 multiplier: self.multiplier.constraintMultiplierTargetValue,
                 constant: layoutConstant
             )
-            
+
             // set label
             layoutConstraint.label = self.label
-            
+
             // set priority
             layoutConstraint.priority = self.priority.constraintPriorityTargetValue
-            
+
             // set constraint
             layoutConstraint.constraint = self
-            
+
             // append
             self.layoutConstraints.append(layoutConstraint)
         }
     }
-    
+
     // MARK: Public
-    
+
     @available(*, deprecated:3.0, message:"Use activate().")
     public func install() {
         self.activate()
     }
-    
+
     @available(*, deprecated:3.0, message:"Use deactivate().")
     public func uninstall() {
         self.deactivate()
     }
-    
+
     public func activate() {
         self.activateIfNeeded()
     }
-    
+
     public func deactivate() {
         self.deactivateIfNeeded()
     }
-    
+
     @discardableResult
     public func update(offset: ConstraintOffsetTarget) -> Constraint {
         self.constant = offset.constraintOffsetTargetValue
         return self
     }
-    
+
     @discardableResult
     public func update(inset: ConstraintInsetTarget) -> Constraint {
         self.constant = inset.constraintInsetTargetValue
         return self
     }
-    
+
     @discardableResult
     public func update(priority: ConstraintPriorityTarget) -> Constraint {
         self.priority = priority.constraintPriorityTargetValue
         return self
     }
-    
+
     @available(*, deprecated:3.0, message:"Use update(offset: ConstraintOffsetTarget) instead.")
     public func updateOffset(amount: ConstraintOffsetTarget) -> Void { self.update(offset: amount) }
-    
+
     @available(*, deprecated:3.0, message:"Use update(inset: ConstraintInsetTarget) instead.")
     public func updateInsets(amount: ConstraintInsetTarget) -> Void { self.update(inset: amount) }
-    
+
     @available(*, deprecated:3.0, message:"Use update(priority: ConstraintPriorityTarget) instead.")
     public func updatePriority(amount: ConstraintPriorityTarget) -> Void { self.update(priority: amount) }
-    
+
     @available(*, obsoleted:3.0, message:"Use update(priority: ConstraintPriorityTarget) instead.")
     public func updatePriorityRequired() -> Void {}
-    
+
     @available(*, obsoleted:3.0, message:"Use update(priority: ConstraintPriorityTarget) instead.")
     public func updatePriorityHigh() -> Void { fatalError("Must be implemented by Concrete subclass.") }
-    
+
     @available(*, obsoleted:3.0, message:"Use update(priority: ConstraintPriorityTarget) instead.")
     public func updatePriorityMedium() -> Void { fatalError("Must be implemented by Concrete subclass.") }
-    
+
     @available(*, obsoleted:3.0, message:"Use update(priority: ConstraintPriorityTarget) instead.")
     public func updatePriorityLow() -> Void { fatalError("Must be implemented by Concrete subclass.") }
-    
+
     // MARK: Internal
-    
+
     internal func updateConstantAndPriorityIfNeeded() {
         for layoutConstraint in self.layoutConstraints {
             let attribute = (layoutConstraint.secondAttribute == .notAnAttribute) ? layoutConstraint.firstAttribute : layoutConstraint.secondAttribute
             layoutConstraint.constant = self.constant.constraintConstantTargetValueFor(layoutAttribute: attribute)
-            
+
             #if os(iOS) || os(tvOS)
                 let requiredPriority: UILayoutPriority = UILayoutPriorityRequired
             #else
                 let requiredPriority: Float = 1000.0
             #endif
-            
-            
+
+
             if (layoutConstraint.priority < requiredPriority), (self.priority.constraintPriorityTargetValue != requiredPriority) {
                 layoutConstraint.priority = self.priority.constraintPriorityTargetValue
             }
         }
     }
-    
+
     internal func activateIfNeeded(updatingExisting: Bool = false) {
         guard let item = self.from.layoutConstraintItem else {
             print("WARNING: SnapKit failed to get from item from constraint. Activate will be a no-op.")
             return
         }
         let layoutConstraints = self.layoutConstraints
-        
+
         if updatingExisting {
             var existingLayoutConstraints: [LayoutConstraint] = []
             for constraint in item.constraints {
                 existingLayoutConstraints += constraint.layoutConstraints
             }
-            
+
             for layoutConstraint in layoutConstraints {
                 let existingLayoutConstraint = existingLayoutConstraints.first { $0 == layoutConstraint }
                 guard let updateLayoutConstraint = existingLayoutConstraint else {
                     fatalError("Updated constraint could not find existing matching constraint to update: \(layoutConstraint)")
                 }
-                
+
                 let updateLayoutAttribute = (updateLayoutConstraint.secondAttribute == .notAnAttribute) ? updateLayoutConstraint.firstAttribute : updateLayoutConstraint.secondAttribute
                 updateLayoutConstraint.constant = self.constant.constraintConstantTargetValueFor(layoutAttribute: updateLayoutAttribute)
             }
@@ -273,7 +273,7 @@ public final class Constraint {
             item.add(constraints: [self])
         }
     }
-    
+
     internal func deactivateIfNeeded() {
         guard let item = self.from.layoutConstraintItem else {
             print("WARNING: SnapKit failed to get from item from constraint. Deactivate will be a no-op.")


### PR DESCRIPTION
I tried to follow the git log of how/why this was changed from `public` to `private`, but I wasn't able to connect the history of `Source/Constraint.swift` that far back.  I'm hoping this was an accidental refactor!

Thanks