### PR TITLE
Fix wrong function call within ConstraintViewDSL

### DIFF
--- a/Source/ConstraintViewDSL.swift
+++ b/Source/ConstraintViewDSL.swift
@@ -74,7 +74,7 @@ public struct ConstraintViewDSL: ConstraintAttributesDSL {
             return self.view.contentCompressionResistancePriority(for: .horizontal)
         }
         set {
-            self.view.setContentHuggingPriority(newValue, for: .horizontal)
+            self.view.setContentCompressionResistancePriority(newValue, for: .horizontal)
         }
     }
     


### PR DESCRIPTION
The setter of ConstraintViewDSL::contentCompressionResistanceHorizontalPriority calls setContentHuggingPriority instead of setCompressionResistancePriority, I think it's a mistake