### PR TITLE
Release v3.2.0 (#403)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ platform :ios, '10.0'
 use_frameworks!
 
 target '<Your Target Name>' do
-    pod 'SnapKit', '~> 3.1.2'
+    pod 'SnapKit', '~> 3.2.0'
 end
 ```
 
@@ -83,7 +83,7 @@ $ brew install carthage
 To integrate SnapKit into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "SnapKit/SnapKit" ~> 3.1.2
+github "SnapKit/SnapKit" ~> 3.2.0
 ```
 
 Run `carthage update` to build the framework and drag the built `SnapKit.framework` into your Xcode project.

--- a/SnapKit.podspec
+++ b/SnapKit.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name = 'SnapKit'
-  s.version = '3.1.2'
+  s.version = '3.2.0'
   s.license = 'MIT'
   s.summary = 'Harness the power of auto layout with a simplified, chainable, and compile time safe syntax.'
   s.homepage = 'https://github.com/SnapKit/SnapKit'
   s.authors = { 'Robert Payne' => 'robertpayne@me.com' }
   s.social_media_url = 'http://twitter.com/robertjpayne'
-  s.source = { :git => 'https://github.com/SnapKit/SnapKit.git', :tag => '3.1.2' }
+  s.source = { :git => 'https://github.com/SnapKit/SnapKit.git', :tag => '3.2.0' }
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.11'

--- a/SnapKit.xcodeproj/project.pbxproj
+++ b/SnapKit.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		EE235FC31C5785DC00C08960 /* ConstraintLayoutSupportDSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE235FBF1C5785DC00C08960 /* ConstraintLayoutSupportDSL.swift */; };
 		EE235FC81C5785E200C08960 /* ConstraintView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE235FC61C5785E200C08960 /* ConstraintView+Extensions.swift */; };
 		EE4910991B19A40200A54F1F /* SnapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EEBCC9D819CC627D0083B827 /* SnapKit.framework */; };
+		EE6087751E4F133E0029CF84 /* ConstraintPriority.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6087741E4F133E0029CF84 /* ConstraintPriority.swift */; };
 		EE6898CB1DA7B3A100D47F33 /* LayoutConstraintItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6898CA1DA7B3A100D47F33 /* LayoutConstraintItem.swift */; };
 		EECDB3741AC0C9B6006BBC11 /* SnapKit.h in Headers */ = {isa = PBXBuildFile; fileRef = EECDB3661AC0C95C006BBC11 /* SnapKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EECDB3931AC0CB52006BBC11 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECDB36A1AC0C95C006BBC11 /* Tests.swift */; };
@@ -71,6 +72,7 @@
 		EE235FBE1C5785DC00C08960 /* ConstraintViewDSL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstraintViewDSL.swift; sourceTree = "<group>"; };
 		EE235FBF1C5785DC00C08960 /* ConstraintLayoutSupportDSL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstraintLayoutSupportDSL.swift; sourceTree = "<group>"; };
 		EE235FC61C5785E200C08960 /* ConstraintView+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConstraintView+Extensions.swift"; sourceTree = "<group>"; };
+		EE6087741E4F133E0029CF84 /* ConstraintPriority.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstraintPriority.swift; sourceTree = "<group>"; };
 		EE6898CA1DA7B3A100D47F33 /* LayoutConstraintItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutConstraintItem.swift; sourceTree = "<group>"; };
 		EE94F6081AC0F10A008767FF /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		EE94F60A1AC0F10F008767FF /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/System/Library/Frameworks/AppKit.framework; sourceTree = DEVELOPER_DIR; };
@@ -187,6 +189,7 @@
 				EE235F6B1C5785C600C08960 /* ConstraintItem.swift */,
 				EE235F6C1C5785C600C08960 /* LayoutConstraint.swift */,
 				EE6898CA1DA7B3A100D47F33 /* LayoutConstraintItem.swift */,
+				EE6087741E4F133E0029CF84 /* ConstraintPriority.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -365,6 +368,7 @@
 				EE235FB51C5785D400C08960 /* ConstraintMakerEditable.swift in Sources */,
 				EEF68FBC1D78653000980C26 /* ConstraintLayoutGuide.swift in Sources */,
 				EE235FAC1C5785D400C08960 /* ConstraintMaker.swift in Sources */,
+				EE6087751E4F133E0029CF84 /* ConstraintPriority.swift in Sources */,
 				EE235F941C5785CE00C08960 /* ConstraintRelatableTarget.swift in Sources */,
 				EEF68FA61D784A5300980C26 /* ConstraintDSL.swift in Sources */,
 				EE235FBB1C5785D400C08960 /* ConstraintMakerExtendable.swift in Sources */,
@@ -506,6 +510,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "io.snapkit.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_BUNDLE_PACKAGE_TYPE = FMWK;
 				PRODUCT_NAME = SnapKit;
+				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				VERSIONING_SYSTEM = "apple-generic";
@@ -525,6 +530,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "io.snapkit.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_BUNDLE_PACKAGE_TYPE = FMWK;
 				PRODUCT_NAME = SnapKit;
+				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VERSIONING_SYSTEM = "apple-generic";
 			};

--- a/Source/ConstraintMakerExtendable.swift
+++ b/Source/ConstraintMakerExtendable.swift
@@ -110,6 +110,12 @@ public class ConstraintMakerExtendable: ConstraintMakerRelatable {
     }
     
     @available(iOS 8.0, *)
+    public var topMargin: ConstraintMakerExtendable {
+        self.description.attributes += .topMargin
+        return self
+    }
+    
+    @available(iOS 8.0, *)
     public var bottomMargin: ConstraintMakerExtendable {
         self.description.attributes += .bottomMargin
         return self

--- a/Source/ConstraintPriority.swift
+++ b/Source/ConstraintPriority.swift
@@ -28,41 +28,41 @@
 #endif
 
 
-public class ConstraintMakerPriortizable: ConstraintMakerFinalizable {
+public struct ConstraintPriority : ExpressibleByFloatLiteral, Equatable {
+    public typealias FloatLiteralType = Float
     
-    @discardableResult
-    public func priority(_ amount: ConstraintPriority) -> ConstraintMakerFinalizable {
-        self.description.priority = amount.value
-        return self
+    public let value: Float
+    
+    public init(floatLiteral value: Float) {
+        self.value = value
     }
     
-    @discardableResult
-    public func priority(_ amount: ConstraintPriorityTarget) -> ConstraintMakerFinalizable {
-        self.description.priority = amount
-        return self
+    public init(_ value: Float) {
+        self.value = value
     }
     
-    @available(*, deprecated:3.0, message:"Use priority(.required) instead.")
-    @discardableResult
-    public func priorityRequired() -> ConstraintMakerFinalizable {
-        return self.priority(.required)
+    public static var required: ConstraintPriority {
+        return 1000.0
     }
     
-    @available(*, deprecated:3.0, message:"Use priority(.high) instead.")
-    @discardableResult
-    public func priorityHigh() -> ConstraintMakerFinalizable {
-        return self.priority(.high)
+    public static var high: ConstraintPriority {
+        return 750.0
     }
     
-    @available(*, deprecated:3.0, message:"Use priority(.medium) instead.")
-    @discardableResult
-    public func priorityMedium() -> ConstraintMakerFinalizable {
-        return self.priority(.medium)
+    public static var medium: ConstraintPriority {
+        #if os(OSX)
+            return 501.0
+        #else
+            return 500.0
+        #endif
+        
     }
     
-    @available(*, deprecated:3.0, message:"Use priority(.low) instead.")
-    @discardableResult
-    public func priorityLow() -> ConstraintMakerFinalizable {
-        return self.priority(.low)
+    public static var low: ConstraintPriority {
+        return 250.0
+    }
+    
+    public static func ==(lhs: ConstraintPriority, rhs: ConstraintPriority) -> Bool {
+        return lhs.value == rhs.value
     }
 }

--- a/Source/ConstraintViewDSL.swift
+++ b/Source/ConstraintViewDSL.swift
@@ -74,7 +74,7 @@ public struct ConstraintViewDSL: ConstraintAttributesDSL {
             return self.view.contentCompressionResistancePriority(for: .horizontal)
         }
         set {
-            self.view.setContentHuggingPriority(newValue, for: .horizontal)
+            self.view.setContentCompressionResistancePriority(newValue, for: .horizontal)
         }
     }
     

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -517,4 +517,27 @@ class SnapKitTests: XCTestCase {
         self.container.snp.setLabel("Hello World")
     }
     
+    func testPriorityShortcuts() {
+        let view = View()
+        self.container.addSubview(view)
+        
+        view.snp.remakeConstraints { make in
+            make.left.equalTo(1000.0).priority(.required)
+        }
+        XCTAssertEqual(self.container.snp_constraints.count, 1, "Should have 1 constraint")
+        XCTAssertEqual(self.container.snp_constraints.first?.priority, ConstraintPriority.required.value)
+        
+        view.snp.remakeConstraints { make in
+            make.left.equalTo(1000.0).priority(.low)
+        }
+        XCTAssertEqual(self.container.snp_constraints.count, 1, "Should have 1 constraint")
+        XCTAssertEqual(self.container.snp_constraints.first?.priority, ConstraintPriority.low.value)
+        
+        view.snp.remakeConstraints { make in
+            make.left.equalTo(1000.0).priority(ConstraintPriority.low.value + 1)
+        }
+        XCTAssertEqual(self.container.snp_constraints.count, 1, "Should have 1 constraint")
+        XCTAssertEqual(self.container.snp_constraints.first?.priority, ConstraintPriority.low.value + 1)
+    }
+    
 }


### PR DESCRIPTION
* make 'layoutConstraints' public again (#382)

* Fix wrong function call within contentCompressionResistanceHorizontalPriority (#387)

* Missing property topMargin on ConstraintMakerExtendable (#393)

This pull request adds the missing property "topMargin" to ConstraintMakerExtendable class.

* Switched main target build settings' "skip install" default settings to YES. (#391)

* Add an isActive API to Constraint

* Priority enum (#345)

* Adds ConstraintPriority enum to ConstraintMakerPrioritizable

* Constraints priority is now more robust

* Adds priority enum function

* Fixes compile error

* Adds failable initializer. Custom macOS medium priority. Adds back deleted methods

* Updates depracation messages

* Improve Priority API's

* Add extra protocol conformances to ConstraintPriority

* Tweak priority API's for offseting

* Tweak priority API's some more and add tests

* Prepare for release