### PR TITLE
Add `Strideble` conformance to `ConstraintPriority `

### DIFF
--- a/Source/ConstraintPriority.swift
+++ b/Source/ConstraintPriority.swift
@@ -27,8 +27,7 @@
     import AppKit
 #endif
 
-
-public struct ConstraintPriority : ExpressibleByFloatLiteral, Equatable {
+public struct ConstraintPriority : ExpressibleByFloatLiteral, Equatable, Strideable {
     public typealias FloatLiteralType = Float
     
     public let value: Float
@@ -64,5 +63,15 @@ public struct ConstraintPriority : ExpressibleByFloatLiteral, Equatable {
     
     public static func ==(lhs: ConstraintPriority, rhs: ConstraintPriority) -> Bool {
         return lhs.value == rhs.value
+    }
+
+    // MARK: Strideable
+
+    public func advanced(by n: FloatLiteralType) -> ConstraintPriority {
+        return ConstraintPriority(floatLiteral: value + n)
+    }
+
+    public func distance(to other: ConstraintPriority) -> FloatLiteralType {
+        return other.value - value
     }
 }

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -539,5 +539,10 @@ class SnapKitTests: XCTestCase {
         XCTAssertEqual(self.container.snp_constraints.count, 1, "Should have 1 constraint")
         XCTAssertEqual(self.container.snp_constraints.first?.priority, ConstraintPriority.low.value + 1)
     }
-    
+
+    func testPriorityStride() {
+        let highPriority: ConstraintPriority = .high
+        let higherPriority: ConstraintPriority = .high + 1
+        XCTAssertEqual(higherPriority.value, highPriority.value + 1)
+    }
 }


### PR DESCRIPTION
This enables sugar like: `.priority(.low + 1)`
Cover the missing part of #324 described here https://github.com/SnapKit/SnapKit/issues/324#issuecomment-249150601