### PR TITLE
Add methods to position views relative to each other in a more easy way.

### DIFF
--- a/Source/ConstraintMaker.swift
+++ b/Source/ConstraintMaker.swift
@@ -143,6 +143,26 @@ public class ConstraintMaker {
         return self.makeExtendableWithAttributes(.centerWithinMargins)
     }
     
+    @discardableResult
+    public func under(_ other: ConstraintView, _ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
+        return top.equalTo(other.snp.bottom, file, line)
+    }
+    
+    @discardableResult
+    public func above(_ other: ConstraintView, _ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
+        return bottom.equalTo(other.snp.top, file, line)
+    }
+    
+    @discardableResult
+    public func left(of other: ConstraintView, _ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
+        return right.equalTo(other.snp.left, file, line)
+    }
+    
+    @discardableResult
+    public func right(of other: ConstraintView, _ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
+        return left.equalTo(other.snp.right, file, line)
+    }
+    
     private let item: LayoutConstraintItem
     private var descriptions = [ConstraintDescription]()
     


### PR DESCRIPTION
Hi! I'm often creating layouts where views are placed in a certain order (e.g top to bottom) and in order to place one view under the order we now have to set constraints like this:

```swift
viewB.snp.makeConstraints { (make) in
    make.top.equalTo(viewA.snp.bottom)
}
```

Which is quite simple, but I think it would be more readable if you could do it like this:

```swift
viewB.snp.makeConstraints { (make) in
    make.under(viewA)
}
```

So I've added a few methods: 'under, above, left:of and right:of' to support this. What do you think?
