### PR TITLE
Add safeArea to ConstraintViewDSL

### DIFF
--- a/SnapKit.xcodeproj/project.pbxproj
+++ b/SnapKit.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2DBA080E1F1FAD66001CFED4 /* Typealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBA080D1F1FAD66001CFED4 /* Typealiases.swift */; };
+		51FD13CC1F76071500B868B8 /* ConstraintSafeAreaDSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FD13CB1F76071500B868B8 /* ConstraintSafeAreaDSL.swift */; };
 		EE235F5F1C5785BC00C08960 /* Debugging.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE235F5E1C5785BC00C08960 /* Debugging.swift */; };
 		EE235F6D1C5785C600C08960 /* Constraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE235F621C5785C600C08960 /* Constraint.swift */; };
 		EE235F701C5785C600C08960 /* ConstraintDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE235F631C5785C600C08960 /* ConstraintDescription.swift */; };
@@ -48,6 +49,7 @@
 
 /* Begin PBXFileReference section */
 		2DBA080D1F1FAD66001CFED4 /* Typealiases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typealiases.swift; sourceTree = "<group>"; };
+		51FD13CB1F76071500B868B8 /* ConstraintSafeAreaDSL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstraintSafeAreaDSL.swift; sourceTree = "<group>"; };
 		537DCE9A1C35CD4100B5B899 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS9.1.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		EE235F5E1C5785BC00C08960 /* Debugging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Debugging.swift; sourceTree = "<group>"; };
 		EE235F621C5785C600C08960 /* Constraint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constraint.swift; sourceTree = "<group>"; };
@@ -146,6 +148,7 @@
 				EE235FBE1C5785DC00C08960 /* ConstraintViewDSL.swift */,
 				EEF68F9D1D78492400980C26 /* ConstraintLayoutGuideDSL.swift */,
 				EE235FBF1C5785DC00C08960 /* ConstraintLayoutSupportDSL.swift */,
+				51FD13CB1F76071500B868B8 /* ConstraintSafeAreaDSL.swift */,
 			);
 			name = DSLs;
 			sourceTree = "<group>";
@@ -391,6 +394,7 @@
 				EE235FC01C5785DC00C08960 /* ConstraintViewDSL.swift in Sources */,
 				EE235F5F1C5785BC00C08960 /* Debugging.swift in Sources */,
 				EE235FC31C5785DC00C08960 /* ConstraintLayoutSupportDSL.swift in Sources */,
+				51FD13CC1F76071500B868B8 /* ConstraintSafeAreaDSL.swift in Sources */,
 				EE235F7F1C5785C600C08960 /* ConstraintRelation.swift in Sources */,
 				EEF68FB41D784FBA00980C26 /* UILayoutSupport+Extensions.swift in Sources */,
 				EE235F701C5785C600C08960 /* ConstraintDescription.swift in Sources */,

--- a/Source/ConstraintSafeAreaDSL.swift
+++ b/Source/ConstraintSafeAreaDSL.swift
@@ -27,44 +27,40 @@
     import AppKit
 #endif
 
-
-public protocol ConstraintRelatableTarget {
-}
-
-extension Int: ConstraintRelatableTarget {
-}
-
-extension UInt: ConstraintRelatableTarget {
-}
-
-extension Float: ConstraintRelatableTarget {
-}
-
-extension Double: ConstraintRelatableTarget {
-}
-
-extension CGFloat: ConstraintRelatableTarget {
-}
-
-extension CGSize: ConstraintRelatableTarget {
-}
-
-extension CGPoint: ConstraintRelatableTarget {
-}
-
-extension ConstraintInsets: ConstraintRelatableTarget {
-}
-
-extension ConstraintItem: ConstraintRelatableTarget {
-}
-
-extension ConstraintView: ConstraintRelatableTarget {
-}
-
-@available(iOS 9.0, OSX 10.11, *)
-extension ConstraintLayoutGuide: ConstraintRelatableTarget {
-}
-
-extension ConstraintSafeAreaDSL: ConstraintRelatableTarget {
+public struct ConstraintSafeAreaDSL: ConstraintAttributesDSL {
+    internal enum ConstraintType {
+        case view(ConstraintView)
+        @available(iOS 9.0, macOS 10.11, *)
+        case guide(ConstraintLayoutGuide)
+    }
+    
+    public var target: AnyObject? {
+        switch self.constraintType {
+        case .view(let view):
+            return view
+        case .guide(let guide):
+            return guide
+        }
+    }
+    
+    internal let constraintType: ConstraintType
+    internal var relatableTarget: ConstraintRelatableTarget {
+        switch self.constraintType {
+        case .view(let view):
+            return view
+        case .guide(let guide):
+            return guide
+        }
+    }
+    
+    internal init(view: ConstraintView) {
+        self.constraintType = .view(view)
+    }
+    
+    @available(iOS 9.0, macOS 10.11, *)
+    internal init(guide: ConstraintLayoutGuide) {
+        self.constraintType = .guide(guide)
+    }
+    
 }
 

--- a/Source/ConstraintViewDSL.swift
+++ b/Source/ConstraintViewDSL.swift
@@ -99,3 +99,15 @@ public struct ConstraintViewDSL: ConstraintAttributesDSL {
     }
     
 }
+
+extension ConstraintViewDSL {
+    // MARK: Safe Area
+    
+    @available(iOS 8.0, *)
+    public var safeArea: ConstraintAttributesDSL {
+        guard #available(iOS 11.0, *) else {
+            return self
+        }
+        return ConstraintLayoutGuideDSL(guide: self.view.safeAreaLayoutGuide)
+    }
+}

--- a/Source/ConstraintViewDSL.swift
+++ b/Source/ConstraintViewDSL.swift
@@ -100,6 +100,7 @@ public struct ConstraintViewDSL: ConstraintAttributesDSL {
     
 }
 
+#if os(iOS) || os(tvOS)
 extension ConstraintViewDSL {
     // MARK: Safe Area
     
@@ -111,3 +112,4 @@ extension ConstraintViewDSL {
         return ConstraintLayoutGuideDSL(guide: self.view.safeAreaLayoutGuide)
     }
 }
+#endif

--- a/Source/ConstraintViewDSL.swift
+++ b/Source/ConstraintViewDSL.swift
@@ -101,15 +101,15 @@ public struct ConstraintViewDSL: ConstraintAttributesDSL {
 }
 
 #if os(iOS) || os(tvOS)
+@available(iOS 8.0, *)
 extension ConstraintViewDSL {
     // MARK: Safe Area
     
-    @available(iOS 8.0, *)
-    public var safeArea: ConstraintAttributesDSL {
+    public var safeArea: ConstraintSafeAreaDSL {
         guard #available(iOS 11.0, tvOS 11.0, *) else {
-            return self
+            return ConstraintSafeAreaDSL(view: self.view)
         }
-        return ConstraintLayoutGuideDSL(guide: self.view.safeAreaLayoutGuide)
+        return ConstraintSafeAreaDSL(guide: self.view.safeAreaLayoutGuide)
     }
 }
 #endif

--- a/Source/ConstraintViewDSL.swift
+++ b/Source/ConstraintViewDSL.swift
@@ -106,7 +106,7 @@ extension ConstraintViewDSL {
     
     @available(iOS 8.0, *)
     public var safeArea: ConstraintAttributesDSL {
-        guard #available(iOS 11.0, *) else {
+        guard #available(iOS 11.0, tvOS 11.0, *) else {
             return self
         }
         return ConstraintLayoutGuideDSL(guide: self.view.safeAreaLayoutGuide)


### PR DESCRIPTION
Hi,

Wanted to implement what was discussed in #448. I made it default to the view if prior to iOS 11. This being because I figured if you want to target an iPhone X, you don't really want to wrap every call to `safeArea.leading` and `safeArea.trailing` in `if #available(iOS 11, *) {`.

It does cause some confusion for iOS 10 and below since you'll still have to use topLayoutGuide on the viewController. But I couldn't figure a way to do that in a good way. I'm still thinking of a way to add an extension that makes sense.

