### PR TITLE
Add update(priority: ConstraintPriority) method

### DIFF
--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -216,7 +216,7 @@ public final class Constraint {
 
     @discardableResult
     public func update(priority: ConstraintPriority) -> Constraint {
-        self.description.priority = amount.value
+        self.priority = priority.value
         return self
     }
 

--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -214,6 +214,12 @@ public final class Constraint {
         return self
     }
 
+    @discardableResult
+    public func update(priority: ConstraintPriority) -> Constraint {
+        self.description.priority = amount.value
+        return self
+    }
+
     @available(*, deprecated:3.0, message:"Use update(offset: ConstraintOffsetTarget) instead.")
     public func updateOffset(amount: ConstraintOffsetTarget) -> Void { self.update(offset: amount) }
 


### PR DESCRIPTION
Allows using priority shortcuts:

```swift
myConstraint.update(priority: .high)
```

This is in line with constraint priority creation:

```swift
make.top.equalTo(label.snp.top).priority(.low)
```