### PR TITLE
[Docs] Update safeAreaLayoutGuide usage - now a property of UIView

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -331,7 +331,7 @@ class MyViewController: UIVewController {
 ```
 
 
-### Snap view to safe layout guide
+### Snap view to safeAreaLayoutGuide
 
 Just like `topLayoutGuide` and `bottomLayoutGuide` using iPhone X's new `safeAreaLayoutGuide` is easy:
 
@@ -347,7 +347,7 @@ class MyViewController: UIVewController {
 
         self.view.addSubview(tableView)
         tableView.snp.makeConstraints { (make) -> Void in
-           make.top.equalTo(self.safeAreaLayoutGuide.snp.top)
+           make.top.equalTo(self.view.safeAreaLayoutGuide.snp.top)
         }
     }
 


### PR DESCRIPTION
First, thanks for the great project! :)

Just a minor update to the docs given that `safeAreaLayoutGuide` is no longer a property of `UIViewController`, but instead `UIView`.

**References**

* https://github.com/SnapKit/SnapKit/issues/448#issuecomment-330114911
* [UIView - safeAreaLayoutGuide](https://developer.apple.com/documentation/uikit/uiview/2891102-safearealayoutguide)