### PR TITLE
Adds 'constraint.isActive = bool' to Constraint

### DIFF
--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -188,6 +188,15 @@ public final class Constraint {
         self.deactivate()
     }
 
+    public func set(isActivated: Bool) {
+        if isActivated {
+            self.activate()
+        }
+        else {
+            self.deactivate()
+        }
+    }
+
     public func activate() {
         self.activateIfNeeded()
     }

--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -49,12 +49,23 @@ public final class Constraint {
     public var layoutConstraints: [LayoutConstraint]
     
     public var isActive: Bool {
-        for layoutConstraint in self.layoutConstraints {
-            if layoutConstraint.isActive {
-                return true
+        set {
+            if newValue {
+                activate()
+            }
+            else {
+                deactivate()
             }
         }
-        return false
+        
+        get {
+            for layoutConstraint in self.layoutConstraints {
+                if layoutConstraint.isActive {
+                    return true
+                }
+            }
+            return false
+        }
     }
     
     // MARK: Initialization
@@ -186,15 +197,6 @@ public final class Constraint {
     @available(*, deprecated:3.0, message:"Use deactivate().")
     public func uninstall() {
         self.deactivate()
-    }
-
-    public func set(isActivated: Bool) {
-        if isActivated {
-            self.activate()
-        }
-        else {
-            self.deactivate()
-        }
     }
 
     public func activate() {

--- a/Source/ConstraintMaker.swift
+++ b/Source/ConstraintMaker.swift
@@ -171,15 +171,7 @@ public class ConstraintMaker {
     }
     
     internal static func makeConstraints(item: LayoutConstraintItem, closure: (_ make: ConstraintMaker) -> Void) {
-        let maker = ConstraintMaker(item: item)
-        closure(maker)
-        var constraints: [Constraint] = []
-        for description in maker.descriptions {
-            guard let constraint = description.constraint else {
-                continue
-            }
-            constraints.append(constraint)
-        }
+        let constraints = prepareConstraints(item: item, closure: closure)
         for constraint in constraints {
             constraint.activateIfNeeded(updatingExisting: false)
         }
@@ -196,15 +188,7 @@ public class ConstraintMaker {
             return
         }
         
-        let maker = ConstraintMaker(item: item)
-        closure(maker)
-        var constraints: [Constraint] = []
-        for description in maker.descriptions {
-            guard let constraint = description.constraint else {
-                continue
-            }
-            constraints.append(constraint)
-        }
+        let constraints = prepareConstraints(item: item, closure: closure)
         for constraint in constraints {
             constraint.activateIfNeeded(updatingExisting: true)
         }

--- a/Tests/SnapKitTests/Tests.swift
+++ b/Tests/SnapKitTests/Tests.swift
@@ -264,6 +264,40 @@ class SnapKitTests: XCTestCase {
         
     }
     
+    func testSetIsActivatedConstraints() {
+        let v1 = View()
+        let v2 = View()
+        self.container.addSubview(v1)
+        self.container.addSubview(v2)
+        
+        var c1: Constraint? = nil
+        var c2: Constraint? = nil
+        
+        v1.snp.prepareConstraints { (make) -> Void in
+            c1 = make.top.equalTo(v2.snp.top).offset(50).constraint
+            c2 = make.left.equalTo(v2.snp.top).offset(50).constraint
+            return
+        }
+        
+        XCTAssertEqual(self.container.snp_constraints.count, 0, "Should have 0 constraints")
+        
+        c1?.set(isActivated: true)
+        c2?.set(isActivated: false)
+        
+        XCTAssertEqual(self.container.snp_constraints.count, 1, "Should have 1 constraint")
+        
+        c1?.set(isActivated: true)
+        c2?.set(isActivated: true)
+        
+        XCTAssertEqual(self.container.snp_constraints.count, 2, "Should have 2 constraints")
+        
+        c1?.set(isActivated: false)
+        c2?.set(isActivated: false)
+        
+        XCTAssertEqual(self.container.snp_constraints.count, 0, "Should have 0 constraints")
+        
+    }
+    
     func testEdgeConstraints() {
         let view = View()
         self.container.addSubview(view)

--- a/Tests/SnapKitTests/Tests.swift
+++ b/Tests/SnapKitTests/Tests.swift
@@ -281,18 +281,18 @@ class SnapKitTests: XCTestCase {
         
         XCTAssertEqual(self.container.snp_constraints.count, 0, "Should have 0 constraints")
         
-        c1?.set(isActivated: true)
-        c2?.set(isActivated: false)
+        c1?.isActive = true
+        c2?.isActive = false
         
         XCTAssertEqual(self.container.snp_constraints.count, 1, "Should have 1 constraint")
         
-        c1?.set(isActivated: true)
-        c2?.set(isActivated: true)
+        c1?.isActive = true
+        c2?.isActive = true
         
         XCTAssertEqual(self.container.snp_constraints.count, 2, "Should have 2 constraints")
         
-        c1?.set(isActivated: false)
-        c2?.set(isActivated: false)
+        c1?.isActive = false
+        c2?.isActive = false
         
         XCTAssertEqual(self.container.snp_constraints.count, 0, "Should have 0 constraints")
         


### PR DESCRIPTION
I've got lots of places where I activate one constraint and deactivate another based on some bool, it has been much nicer to use a function that accepts a bool:

```swift
let buttonVisible = someCondition
wideConstraint.isActive = buttonVisible
narrowConstraint.isActive = !buttonVisible
```

Or as a diff to show what I mean:

```diff
 let buttonVisible = someCondition
-if buttonVisible {
-    wideConstraint.activate()
-    narrowConstraint.deactivate()
-else {
-    wideConstraint.deactivate()
-    narrowConstraint.activate()
-}
+wideConstraint.isActive = buttonVisible
+narrowConstraint.isActive = !buttonVisible
```

Function name was the first that popped in my head, but I was following the `update(offset: ..)` naming scheme.  Tests included, plus a minor refactor to `prepare/make/update–Constraints` to delegate identical code to `prepareConstraints`.