### PR TITLE
make ConstraintAttributes conform to ExpressibleByIntegerLiteral

### DIFF
--- a/Source/ConstraintAttributes.swift
+++ b/Source/ConstraintAttributes.swift
@@ -28,7 +28,9 @@
 #endif
 
 
-internal struct ConstraintAttributes : OptionSet {
+internal struct ConstraintAttributes : OptionSet, ExpressibleByIntegerLiteral {
+    
+    typealias IntegerLiteralType = UInt
     
     internal init(rawValue: UInt) {
         self.rawValue = rawValue
@@ -39,10 +41,13 @@ internal struct ConstraintAttributes : OptionSet {
     internal init(nilLiteral: ()) {
         self.rawValue = 0
     }
+    internal init(integerLiteral rawValue: IntegerLiteralType) {
+        self.init(rawValue: rawValue)
+    }
     
     internal private(set) var rawValue: UInt
-    internal static var allZeros: ConstraintAttributes { return self.init(0) }
-    internal static func convertFromNilLiteral() -> ConstraintAttributes { return self.init(0) }
+    internal static var allZeros: ConstraintAttributes { return 0 }
+    internal static func convertFromNilLiteral() -> ConstraintAttributes { return 0 }
     internal var boolValue: Bool { return self.rawValue != 0 }
     
     internal func toRaw() -> UInt { return self.rawValue }
@@ -51,57 +56,57 @@ internal struct ConstraintAttributes : OptionSet {
     
     // normal
     
-    internal static var none: ConstraintAttributes { return self.init(0) }
-    internal static var left: ConstraintAttributes { return self.init(1) }
-    internal static var top: ConstraintAttributes {  return self.init(2) }
-    internal static var right: ConstraintAttributes { return self.init(4) }
-    internal static var bottom: ConstraintAttributes { return self.init(8) }
-    internal static var leading: ConstraintAttributes { return self.init(16) }
-    internal static var trailing: ConstraintAttributes { return self.init(32) }
-    internal static var width: ConstraintAttributes { return self.init(64) }
-    internal static var height: ConstraintAttributes { return self.init(128) }
-    internal static var centerX: ConstraintAttributes { return self.init(256) }
-    internal static var centerY: ConstraintAttributes { return self.init(512) }
-    internal static var lastBaseline: ConstraintAttributes { return self.init(1024) }
+    internal static var none: ConstraintAttributes { return 0 }
+    internal static var left: ConstraintAttributes { return 1 }
+    internal static var top: ConstraintAttributes {  return 2 }
+    internal static var right: ConstraintAttributes { return 4 }
+    internal static var bottom: ConstraintAttributes { return 8 }
+    internal static var leading: ConstraintAttributes { return 16 }
+    internal static var trailing: ConstraintAttributes { return 32 }
+    internal static var width: ConstraintAttributes { return 64 }
+    internal static var height: ConstraintAttributes { return 128 }
+    internal static var centerX: ConstraintAttributes { return 256 }
+    internal static var centerY: ConstraintAttributes { return 512 }
+    internal static var lastBaseline: ConstraintAttributes { return 1024 }
     
     @available(iOS 8.0, OSX 10.11, *)
-    internal static var firstBaseline: ConstraintAttributes { return self.init(2048) }
+    internal static var firstBaseline: ConstraintAttributes { return 2048 }
     
     @available(iOS 8.0, *)
-    internal static var leftMargin: ConstraintAttributes { return self.init(4096) }
+    internal static var leftMargin: ConstraintAttributes { return 4096 }
     
     @available(iOS 8.0, *)
-    internal static var rightMargin: ConstraintAttributes { return self.init(8192) }
+    internal static var rightMargin: ConstraintAttributes { return 8192 }
     
     @available(iOS 8.0, *)
-    internal static var topMargin: ConstraintAttributes { return self.init(16384) }
+    internal static var topMargin: ConstraintAttributes { return 16384 }
     
     @available(iOS 8.0, *)
-    internal static var bottomMargin: ConstraintAttributes { return self.init(32768) }
+    internal static var bottomMargin: ConstraintAttributes { return 32768 }
     
     @available(iOS 8.0, *)
-    internal static var leadingMargin: ConstraintAttributes { return self.init(65536) }
+    internal static var leadingMargin: ConstraintAttributes { return 65536 }
     
     @available(iOS 8.0, *)
-    internal static var trailingMargin: ConstraintAttributes { return self.init(131072) }
+    internal static var trailingMargin: ConstraintAttributes { return 131072 }
     
     @available(iOS 8.0, *)
-    internal static var centerXWithinMargins: ConstraintAttributes { return self.init(262144) }
+    internal static var centerXWithinMargins: ConstraintAttributes { return 262144 }
     
     @available(iOS 8.0, *)
-    internal static var centerYWithinMargins: ConstraintAttributes { return self.init(524288) }
+    internal static var centerYWithinMargins: ConstraintAttributes { return 524288 }
     
     // aggregates
     
-    internal static var edges: ConstraintAttributes { return self.init(15) }
-    internal static var size: ConstraintAttributes { return self.init(192) }
-    internal static var center: ConstraintAttributes { return self.init(768) }
+    internal static var edges: ConstraintAttributes { return 15 }
+    internal static var size: ConstraintAttributes { return 192 }
+    internal static var center: ConstraintAttributes { return 768 }
     
     @available(iOS 8.0, *)
-    internal static var margins: ConstraintAttributes { return self.init(61440) }
+    internal static var margins: ConstraintAttributes { return 61440 }
     
     @available(iOS 8.0, *)
-    internal static var centerWithinMargins: ConstraintAttributes { return self.init(786432) }
+    internal static var centerWithinMargins: ConstraintAttributes { return 786432 }
     
     internal var layoutAttributes:[LayoutAttribute] {
         var attrs = [LayoutAttribute]()


### PR DESCRIPTION
make:
```Swift
internal static var left: ConstraintAttributes { return self.init(1) } 
```
to:
```Swift
internal static var left: ConstraintAttributes { return 1 } 
```
and so on