### PR TITLE
use switch-case in ConstraintInsetTarget and constraintOffsetTargetValue will be better?

### DIFF
--- a/Source/ConstraintInsetTarget.swift
+++ b/Source/ConstraintInsetTarget.swift
@@ -52,19 +52,20 @@ extension ConstraintInsets: ConstraintInsetTarget {
 extension ConstraintInsetTarget {
 
     internal var constraintInsetTargetValue: ConstraintInsets {
-        if let amount = self as? ConstraintInsets {
+        switch self {
+        case let amount as ConstraintInsets:
             return amount
-        } else if let amount = self as? Float {
+        case let amount as Float:
             return ConstraintInsets(top: CGFloat(amount), left: CGFloat(amount), bottom: CGFloat(amount), right: CGFloat(amount))
-        } else if let amount = self as? Double {
+        case let amount as Double:
             return ConstraintInsets(top: CGFloat(amount), left: CGFloat(amount), bottom: CGFloat(amount), right: CGFloat(amount))
-        } else if let amount = self as? CGFloat {
+        case let amount as CGFloat:
             return ConstraintInsets(top: amount, left: amount, bottom: amount, right: amount)
-        } else if let amount = self as? Int {
+        case let amount as Int:
             return ConstraintInsets(top: CGFloat(amount), left: CGFloat(amount), bottom: CGFloat(amount), right: CGFloat(amount))
-        } else if let amount = self as? UInt {
+        case let amount as UInt:
             return ConstraintInsets(top: CGFloat(amount), left: CGFloat(amount), bottom: CGFloat(amount), right: CGFloat(amount))
-        } else {
+        default:
             return ConstraintInsets(top: 0, left: 0, bottom: 0, right: 0)
         }
     }

--- a/Source/ConstraintOffsetTarget.swift
+++ b/Source/ConstraintOffsetTarget.swift
@@ -50,17 +50,18 @@ extension ConstraintOffsetTarget {
     
     internal var constraintOffsetTargetValue: CGFloat {
         let offset: CGFloat
-        if let amount = self as? Float {
+        switch self {
+        case let amount as Float:
             offset = CGFloat(amount)
-        } else if let amount = self as? Double {
+        case let amount as Double:
             offset = CGFloat(amount)
-        } else if let amount = self as? CGFloat {
+        case let amount as CGFloat:
             offset = CGFloat(amount)
-        } else if let amount = self as? Int {
+        case let amount as Int:
             offset = CGFloat(amount)
-        } else if let amount = self as? UInt {
+        case let amount as UInt:
             offset = CGFloat(amount)
-        } else {
+        default:
             offset = 0.0
         }
         return offset


### PR DESCRIPTION
replace if-else to switch-case in ConstraintInsetTarget and constraintOffsetTargetValue
before:
```Swift
if let amount = self as? Float {
...
} else if let amount = self as? Double{
...
```

change to:
```Swift
switch self{
case let amount as Float:
...
case let amount as Double:
...
}
```

will that seems to be better?