### PR TITLE
Refactor ACL and ConstraintAttributes

### DIFF
--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -29,8 +29,8 @@
 
 public final class Constraint {
 
-    internal let sourceLocation: (String, UInt)
-    internal let label: String?
+    let sourceLocation: (String, UInt)
+    let label: String?
 
     private let from: ConstraintItem
     private let to: ConstraintItem
@@ -70,7 +70,7 @@ public final class Constraint {
     
     // MARK: Initialization
 
-    internal init(from: ConstraintItem,
+    init(from: ConstraintItem,
                   to: ConstraintItem,
                   relation: ConstraintRelation,
                   sourceLocation: (String, UInt),
@@ -254,7 +254,7 @@ public final class Constraint {
 
     // MARK: Internal
 
-    internal func updateConstantAndPriorityIfNeeded() {
+    func updateConstantAndPriorityIfNeeded() {
         for layoutConstraint in self.layoutConstraints {
             let attribute = (layoutConstraint.secondAttribute == .notAnAttribute) ? layoutConstraint.firstAttribute : layoutConstraint.secondAttribute
             layoutConstraint.constant = self.constant.constraintConstantTargetValueFor(layoutAttribute: attribute)
@@ -266,7 +266,7 @@ public final class Constraint {
         }
     }
 
-    internal func activateIfNeeded(updatingExisting: Bool = false) {
+    func activateIfNeeded(updatingExisting: Bool = false) {
         guard let item = self.from.layoutConstraintItem else {
             print("WARNING: SnapKit failed to get from item from constraint. Activate will be a no-op.")
             return
@@ -294,7 +294,7 @@ public final class Constraint {
         }
     }
 
-    internal func deactivateIfNeeded() {
+    func deactivateIfNeeded() {
         guard let item = self.from.layoutConstraintItem else {
             print("WARNING: SnapKit failed to get from item from constraint. Deactivate will be a no-op.")
             return

--- a/Source/ConstraintAttributes.swift
+++ b/Source/ConstraintAttributes.swift
@@ -110,66 +110,66 @@ struct ConstraintAttributes : OptionSet, ExpressibleByIntegerLiteral {
     
     var layoutAttributes:[LayoutAttribute] {
         var attrs = [LayoutAttribute]()
-        if (self.contains(ConstraintAttributes.left)) {
+        if (self.contains(.left)) {
             attrs.append(.left)
         }
-        if (self.contains(ConstraintAttributes.top)) {
+        if (self.contains(.top)) {
             attrs.append(.top)
         }
-        if (self.contains(ConstraintAttributes.right)) {
+        if (self.contains(.right)) {
             attrs.append(.right)
         }
-        if (self.contains(ConstraintAttributes.bottom)) {
+        if (self.contains(.bottom)) {
             attrs.append(.bottom)
         }
-        if (self.contains(ConstraintAttributes.leading)) {
+        if (self.contains(.leading)) {
             attrs.append(.leading)
         }
-        if (self.contains(ConstraintAttributes.trailing)) {
+        if (self.contains(.trailing)) {
             attrs.append(.trailing)
         }
-        if (self.contains(ConstraintAttributes.width)) {
+        if (self.contains(.width)) {
             attrs.append(.width)
         }
-        if (self.contains(ConstraintAttributes.height)) {
+        if (self.contains(.height)) {
             attrs.append(.height)
         }
-        if (self.contains(ConstraintAttributes.centerX)) {
+        if (self.contains(.centerX)) {
             attrs.append(.centerX)
         }
-        if (self.contains(ConstraintAttributes.centerY)) {
+        if (self.contains(.centerY)) {
             attrs.append(.centerY)
         }
-        if (self.contains(ConstraintAttributes.lastBaseline)) {
+        if (self.contains(.lastBaseline)) {
             attrs.append(.lastBaseline)
         }
         
         #if os(iOS) || os(tvOS)
-            if (self.contains(ConstraintAttributes.firstBaseline)) {
+            if (self.contains(.firstBaseline)) {
                 attrs.append(.firstBaseline)
             }
-            if (self.contains(ConstraintAttributes.leftMargin)) {
+            if (self.contains(.leftMargin)) {
                 attrs.append(.leftMargin)
             }
-            if (self.contains(ConstraintAttributes.rightMargin)) {
+            if (self.contains(.rightMargin)) {
                 attrs.append(.rightMargin)
             }
-            if (self.contains(ConstraintAttributes.topMargin)) {
+            if (self.contains(.topMargin)) {
                 attrs.append(.topMargin)
             }
-            if (self.contains(ConstraintAttributes.bottomMargin)) {
+            if (self.contains(.bottomMargin)) {
                 attrs.append(.bottomMargin)
             }
-            if (self.contains(ConstraintAttributes.leadingMargin)) {
+            if (self.contains(.leadingMargin)) {
                 attrs.append(.leadingMargin)
             }
-            if (self.contains(ConstraintAttributes.trailingMargin)) {
+            if (self.contains(.trailingMargin)) {
                 attrs.append(.trailingMargin)
             }
-            if (self.contains(ConstraintAttributes.centerXWithinMargins)) {
+            if (self.contains(.centerXWithinMargins)) {
                 attrs.append(.centerXWithinMargins)
             }
-            if (self.contains(ConstraintAttributes.centerYWithinMargins)) {
+            if (self.contains(.centerYWithinMargins)) {
                 attrs.append(.centerYWithinMargins)
             }
         #endif

--- a/Source/ConstraintAttributes.swift
+++ b/Source/ConstraintAttributes.swift
@@ -28,87 +28,87 @@
 #endif
 
 
-internal struct ConstraintAttributes : OptionSet, ExpressibleByIntegerLiteral {
+struct ConstraintAttributes : OptionSet, ExpressibleByIntegerLiteral {
     
     typealias IntegerLiteralType = UInt
     
-    internal init(rawValue: UInt) {
+    init(rawValue: UInt) {
         self.rawValue = rawValue
     }
-    internal init(_ rawValue: UInt) {
+    init(_ rawValue: UInt) {
         self.init(rawValue: rawValue)
     }
-    internal init(nilLiteral: ()) {
+    init(nilLiteral: ()) {
         self.rawValue = 0
     }
-    internal init(integerLiteral rawValue: IntegerLiteralType) {
+    init(integerLiteral rawValue: IntegerLiteralType) {
         self.init(rawValue: rawValue)
     }
     
-    internal private(set) var rawValue: UInt
-    internal static var allZeros: ConstraintAttributes { return 0 }
-    internal static func convertFromNilLiteral() -> ConstraintAttributes { return 0 }
-    internal var boolValue: Bool { return self.rawValue != 0 }
+    private(set) var rawValue: UInt
+    static var allZeros: ConstraintAttributes { return 0 }
+    static func convertFromNilLiteral() -> ConstraintAttributes { return 0 }
+    var boolValue: Bool { return self.rawValue != 0 }
     
-    internal func toRaw() -> UInt { return self.rawValue }
-    internal static func fromRaw(_ raw: UInt) -> ConstraintAttributes? { return self.init(raw) }
-    internal static func fromMask(_ raw: UInt) -> ConstraintAttributes { return self.init(raw) }
+    func toRaw() -> UInt { return self.rawValue }
+    static func fromRaw(_ raw: UInt) -> ConstraintAttributes? { return self.init(raw) }
+    static func fromMask(_ raw: UInt) -> ConstraintAttributes { return self.init(raw) }
     
     // normal
     
-    internal static var none: ConstraintAttributes { return 0 }
-    internal static var left: ConstraintAttributes { return 1 }
-    internal static var top: ConstraintAttributes {  return 2 }
-    internal static var right: ConstraintAttributes { return 4 }
-    internal static var bottom: ConstraintAttributes { return 8 }
-    internal static var leading: ConstraintAttributes { return 16 }
-    internal static var trailing: ConstraintAttributes { return 32 }
-    internal static var width: ConstraintAttributes { return 64 }
-    internal static var height: ConstraintAttributes { return 128 }
-    internal static var centerX: ConstraintAttributes { return 256 }
-    internal static var centerY: ConstraintAttributes { return 512 }
-    internal static var lastBaseline: ConstraintAttributes { return 1024 }
+    static var none: ConstraintAttributes { return 0 }
+    static var left: ConstraintAttributes { return 1 }
+    static var top: ConstraintAttributes {  return 2 }
+    static var right: ConstraintAttributes { return 4 }
+    static var bottom: ConstraintAttributes { return 8 }
+    static var leading: ConstraintAttributes { return 16 }
+    static var trailing: ConstraintAttributes { return 32 }
+    static var width: ConstraintAttributes { return 64 }
+    static var height: ConstraintAttributes { return 128 }
+    static var centerX: ConstraintAttributes { return 256 }
+    static var centerY: ConstraintAttributes { return 512 }
+    static var lastBaseline: ConstraintAttributes { return 1024 }
     
     @available(iOS 8.0, OSX 10.11, *)
-    internal static var firstBaseline: ConstraintAttributes { return 2048 }
+    static var firstBaseline: ConstraintAttributes { return 2048 }
     
     @available(iOS 8.0, *)
-    internal static var leftMargin: ConstraintAttributes { return 4096 }
+    static var leftMargin: ConstraintAttributes { return 4096 }
     
     @available(iOS 8.0, *)
-    internal static var rightMargin: ConstraintAttributes { return 8192 }
+    static var rightMargin: ConstraintAttributes { return 8192 }
     
     @available(iOS 8.0, *)
-    internal static var topMargin: ConstraintAttributes { return 16384 }
+    static var topMargin: ConstraintAttributes { return 16384 }
     
     @available(iOS 8.0, *)
-    internal static var bottomMargin: ConstraintAttributes { return 32768 }
+    static var bottomMargin: ConstraintAttributes { return 32768 }
     
     @available(iOS 8.0, *)
-    internal static var leadingMargin: ConstraintAttributes { return 65536 }
+    static var leadingMargin: ConstraintAttributes { return 65536 }
     
     @available(iOS 8.0, *)
-    internal static var trailingMargin: ConstraintAttributes { return 131072 }
+    static var trailingMargin: ConstraintAttributes { return 131072 }
     
     @available(iOS 8.0, *)
-    internal static var centerXWithinMargins: ConstraintAttributes { return 262144 }
+    static var centerXWithinMargins: ConstraintAttributes { return 262144 }
     
     @available(iOS 8.0, *)
-    internal static var centerYWithinMargins: ConstraintAttributes { return 524288 }
+    static var centerYWithinMargins: ConstraintAttributes { return 524288 }
     
     // aggregates
     
-    internal static var edges: ConstraintAttributes { return 15 }
-    internal static var size: ConstraintAttributes { return 192 }
-    internal static var center: ConstraintAttributes { return 768 }
+    static var edges: ConstraintAttributes { return 15 }
+    static var size: ConstraintAttributes { return 192 }
+    static var center: ConstraintAttributes { return 768 }
     
     @available(iOS 8.0, *)
-    internal static var margins: ConstraintAttributes { return 61440 }
+    static var margins: ConstraintAttributes { return 61440 }
     
     @available(iOS 8.0, *)
-    internal static var centerWithinMargins: ConstraintAttributes { return 786432 }
+    static var centerWithinMargins: ConstraintAttributes { return 786432 }
     
-    internal var layoutAttributes:[LayoutAttribute] {
+    var layoutAttributes:[LayoutAttribute] {
         var attrs = [LayoutAttribute]()
         if (self.contains(ConstraintAttributes.left)) {
             attrs.append(.left)
@@ -178,18 +178,18 @@ internal struct ConstraintAttributes : OptionSet, ExpressibleByIntegerLiteral {
     }
 }
 
-internal func + (left: ConstraintAttributes, right: ConstraintAttributes) -> ConstraintAttributes {
+func + (left: ConstraintAttributes, right: ConstraintAttributes) -> ConstraintAttributes {
     return left.union(right)
 }
 
-internal func +=(left: inout ConstraintAttributes, right: ConstraintAttributes) {
+func +=(left: inout ConstraintAttributes, right: ConstraintAttributes) {
     left.formUnion(right)
 }
 
-internal func -=(left: inout ConstraintAttributes, right: ConstraintAttributes) {
+func -=(left: inout ConstraintAttributes, right: ConstraintAttributes) {
     left.subtract(right)
 }
 
-internal func ==(left: ConstraintAttributes, right: ConstraintAttributes) -> Bool {
+func ==(left: ConstraintAttributes, right: ConstraintAttributes) -> Bool {
     return left.rawValue == right.rawValue
 }

--- a/Source/ConstraintConstantTarget.swift
+++ b/Source/ConstraintConstantTarget.swift
@@ -42,7 +42,7 @@ extension ConstraintInsets: ConstraintConstantTarget {
 
 extension ConstraintConstantTarget {
     
-    internal func constraintConstantTargetValueFor(layoutAttribute: LayoutAttribute) -> CGFloat {
+    func constraintConstantTargetValueFor(layoutAttribute: LayoutAttribute) -> CGFloat {
         if let value = self as? CGFloat {
             return value
         }

--- a/Source/ConstraintDSL.swift
+++ b/Source/ConstraintDSL.swift
@@ -56,55 +56,55 @@ extension ConstraintBasicAttributesDSL {
     // MARK: Basics
     
     public var left: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.left)
+        return ConstraintItem(target: self.target, attributes: .left)
     }
     
     public var top: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.top)
+        return ConstraintItem(target: self.target, attributes: .top)
     }
     
     public var right: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.right)
+        return ConstraintItem(target: self.target, attributes: .right)
     }
     
     public var bottom: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.bottom)
+        return ConstraintItem(target: self.target, attributes: .bottom)
     }
     
     public var leading: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.leading)
+        return ConstraintItem(target: self.target, attributes: .leading)
     }
     
     public var trailing: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.trailing)
+        return ConstraintItem(target: self.target, attributes: .trailing)
     }
     
     public var width: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.width)
+        return ConstraintItem(target: self.target, attributes: .width)
     }
     
     public var height: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.height)
+        return ConstraintItem(target: self.target, attributes: .height)
     }
     
     public var centerX: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.centerX)
+        return ConstraintItem(target: self.target, attributes: .centerX)
     }
     
     public var centerY: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.centerY)
+        return ConstraintItem(target: self.target, attributes: .centerY)
     }
     
     public var edges: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.edges)
+        return ConstraintItem(target: self.target, attributes: .edges)
     }
     
     public var size: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.size)
+        return ConstraintItem(target: self.target, attributes: .size)
     }
     
     public var center: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.center)
+        return ConstraintItem(target: self.target, attributes: .center)
     }
     
 }
@@ -117,69 +117,69 @@ extension ConstraintAttributesDSL {
     
     @available(*, deprecated:3.0, message:"Use .lastBaseline instead")
     public var baseline: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.lastBaseline)
+        return ConstraintItem(target: self.target, attributes: .lastBaseline)
     }
     
     @available(iOS 8.0, OSX 10.11, *)
     public var lastBaseline: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.lastBaseline)
+        return ConstraintItem(target: self.target, attributes: .lastBaseline)
     }
     
     @available(iOS 8.0, OSX 10.11, *)
     public var firstBaseline: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.firstBaseline)
+        return ConstraintItem(target: self.target, attributes: .firstBaseline)
     }
     
     // MARK: Margins
     
     @available(iOS 8.0, *)
     public var leftMargin: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.leftMargin)
+        return ConstraintItem(target: self.target, attributes: .leftMargin)
     }
     
     @available(iOS 8.0, *)
     public var topMargin: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.topMargin)
+        return ConstraintItem(target: self.target, attributes: .topMargin)
     }
     
     @available(iOS 8.0, *)
     public var rightMargin: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.rightMargin)
+        return ConstraintItem(target: self.target, attributes: .rightMargin)
     }
     
     @available(iOS 8.0, *)
     public var bottomMargin: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.bottomMargin)
+        return ConstraintItem(target: self.target, attributes: .bottomMargin)
     }
     
     @available(iOS 8.0, *)
     public var leadingMargin: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.leadingMargin)
+        return ConstraintItem(target: self.target, attributes: .leadingMargin)
     }
     
     @available(iOS 8.0, *)
     public var trailingMargin: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.trailingMargin)
+        return ConstraintItem(target: self.target, attributes: .trailingMargin)
     }
     
     @available(iOS 8.0, *)
     public var centerXWithinMargins: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.centerXWithinMargins)
+        return ConstraintItem(target: self.target, attributes: .centerXWithinMargins)
     }
     
     @available(iOS 8.0, *)
     public var centerYWithinMargins: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.centerYWithinMargins)
+        return ConstraintItem(target: self.target, attributes: .centerYWithinMargins)
     }
     
     @available(iOS 8.0, *)
     public var margins: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.margins)
+        return ConstraintItem(target: self.target, attributes: .margins)
     }
     
     @available(iOS 8.0, *)
     public var centerWithinMargins: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.centerWithinMargins)
+        return ConstraintItem(target: self.target, attributes: .centerWithinMargins)
     }
     
 }

--- a/Source/ConstraintDescription.swift
+++ b/Source/ConstraintDescription.swift
@@ -30,16 +30,16 @@
 
 public class ConstraintDescription {
     
-    internal let item: LayoutConstraintItem
-    internal var attributes: ConstraintAttributes
-    internal var relation: ConstraintRelation? = nil
-    internal var sourceLocation: (String, UInt)? = nil
-    internal var label: String? = nil
-    internal var related: ConstraintItem? = nil
-    internal var multiplier: ConstraintMultiplierTarget = 1.0
-    internal var constant: ConstraintConstantTarget = 0.0
-    internal var priority: ConstraintPriorityTarget = 1000.0
-    internal lazy var constraint: Constraint? = {
+    let item: LayoutConstraintItem
+    var attributes: ConstraintAttributes
+    var relation: ConstraintRelation? = nil
+    var sourceLocation: (String, UInt)? = nil
+    var label: String? = nil
+    var related: ConstraintItem? = nil
+    var multiplier: ConstraintMultiplierTarget = 1.0
+    var constant: ConstraintConstantTarget = 0.0
+    var priority: ConstraintPriorityTarget = 1000.0
+    lazy var constraint: Constraint? = {
         guard let relation = self.relation,
               let related = self.related,
               let sourceLocation = self.sourceLocation else {
@@ -61,7 +61,7 @@ public class ConstraintDescription {
     
     // MARK: Initialization
     
-    internal init(item: LayoutConstraintItem, attributes: ConstraintAttributes) {
+    init(item: LayoutConstraintItem, attributes: ConstraintAttributes) {
         self.item = item
         self.attributes = attributes
     }

--- a/Source/ConstraintInsetTarget.swift
+++ b/Source/ConstraintInsetTarget.swift
@@ -51,7 +51,7 @@ extension ConstraintInsets: ConstraintInsetTarget {
 
 extension ConstraintInsetTarget {
 
-    internal var constraintInsetTargetValue: ConstraintInsets {
+    var constraintInsetTargetValue: ConstraintInsets {
         if let amount = self as? ConstraintInsets {
             return amount
         } else if let amount = self as? Float {

--- a/Source/ConstraintItem.swift
+++ b/Source/ConstraintItem.swift
@@ -30,15 +30,15 @@
 
 public final class ConstraintItem {
     
-    internal weak var target: AnyObject?
-    internal let attributes: ConstraintAttributes
+    weak var target: AnyObject?
+    let attributes: ConstraintAttributes
     
-    internal init(target: AnyObject?, attributes: ConstraintAttributes) {
+    init(target: AnyObject?, attributes: ConstraintAttributes) {
         self.target = target
         self.attributes = attributes
     }
     
-    internal var layoutConstraintItem: LayoutConstraintItem? {
+    var layoutConstraintItem: LayoutConstraintItem? {
         return self.target as? LayoutConstraintItem
     }
     

--- a/Source/ConstraintLayoutGuideDSL.swift
+++ b/Source/ConstraintLayoutGuideDSL.swift
@@ -56,9 +56,9 @@ public struct ConstraintLayoutGuideDSL: ConstraintAttributesDSL {
         return self.guide
     }
     
-    internal let guide: ConstraintLayoutGuide
+    let guide: ConstraintLayoutGuide
     
-    internal init(guide: ConstraintLayoutGuide) {
+    init(guide: ConstraintLayoutGuide) {
         self.guide = guide
         
     }

--- a/Source/ConstraintLayoutSupportDSL.swift
+++ b/Source/ConstraintLayoutSupportDSL.swift
@@ -43,14 +43,14 @@ public struct ConstraintLayoutSupportDSL: ConstraintDSL {
     }
     
     public var top: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.top)
+        return ConstraintItem(target: self.target, attributes: .top)
     }
     
     public var bottom: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.bottom)
+        return ConstraintItem(target: self.target, attributes: .bottom)
     }
     
     public var height: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.height)
+        return ConstraintItem(target: self.target, attributes: .height)
     }
 }

--- a/Source/ConstraintLayoutSupportDSL.swift
+++ b/Source/ConstraintLayoutSupportDSL.swift
@@ -35,9 +35,9 @@ public struct ConstraintLayoutSupportDSL: ConstraintDSL {
         return self.support
     }
     
-    internal let support: ConstraintLayoutSupport
+    let support: ConstraintLayoutSupport
     
-    internal init(support: ConstraintLayoutSupport) {
+    init(support: ConstraintLayoutSupport) {
         self.support = support
         
     }

--- a/Source/ConstraintMaker.swift
+++ b/Source/ConstraintMaker.swift
@@ -146,18 +146,18 @@ public class ConstraintMaker {
     private let item: LayoutConstraintItem
     private var descriptions = [ConstraintDescription]()
     
-    internal init(item: LayoutConstraintItem) {
+    init(item: LayoutConstraintItem) {
         self.item = item
         self.item.prepare()
     }
     
-    internal func makeExtendableWithAttributes(_ attributes: ConstraintAttributes) -> ConstraintMakerExtendable {
+    func makeExtendableWithAttributes(_ attributes: ConstraintAttributes) -> ConstraintMakerExtendable {
         let description = ConstraintDescription(item: self.item, attributes: attributes)
         self.descriptions.append(description)
         return ConstraintMakerExtendable(description)
     }
     
-    internal static func prepareConstraints(item: LayoutConstraintItem, closure: (_ make: ConstraintMaker) -> Void) -> [Constraint] {
+    static func prepareConstraints(item: LayoutConstraintItem, closure: (_ make: ConstraintMaker) -> Void) -> [Constraint] {
         let maker = ConstraintMaker(item: item)
         closure(maker)
         var constraints: [Constraint] = []
@@ -170,19 +170,19 @@ public class ConstraintMaker {
         return constraints
     }
     
-    internal static func makeConstraints(item: LayoutConstraintItem, closure: (_ make: ConstraintMaker) -> Void) {
+    static func makeConstraints(item: LayoutConstraintItem, closure: (_ make: ConstraintMaker) -> Void) {
         let constraints = prepareConstraints(item: item, closure: closure)
         for constraint in constraints {
             constraint.activateIfNeeded(updatingExisting: false)
         }
     }
     
-    internal static func remakeConstraints(item: LayoutConstraintItem, closure: (_ make: ConstraintMaker) -> Void) {
+    static func remakeConstraints(item: LayoutConstraintItem, closure: (_ make: ConstraintMaker) -> Void) {
         self.removeConstraints(item: item)
         self.makeConstraints(item: item, closure: closure)
     }
     
-    internal static func updateConstraints(item: LayoutConstraintItem, closure: (_ make: ConstraintMaker) -> Void) {
+    static func updateConstraints(item: LayoutConstraintItem, closure: (_ make: ConstraintMaker) -> Void) {
         guard item.constraints.count > 0 else {
             self.makeConstraints(item: item, closure: closure)
             return
@@ -194,7 +194,7 @@ public class ConstraintMaker {
         }
     }
     
-    internal static func removeConstraints(item: LayoutConstraintItem) {
+    static func removeConstraints(item: LayoutConstraintItem) {
         let constraints = item.constraints
         for constraint in constraints {
             constraint.deactivateIfNeeded()

--- a/Source/ConstraintMakerFinalizable.swift
+++ b/Source/ConstraintMakerFinalizable.swift
@@ -30,9 +30,9 @@
 
 public class ConstraintMakerFinalizable {
     
-    internal let description: ConstraintDescription
+    let description: ConstraintDescription
     
-    internal init(_ description: ConstraintDescription) {
+    init(_ description: ConstraintDescription) {
         self.description = description
     }
     

--- a/Source/ConstraintMakerRelatable.swift
+++ b/Source/ConstraintMakerRelatable.swift
@@ -41,7 +41,7 @@ public class ConstraintMakerRelatable {
         let constant: ConstraintConstantTarget
         
         if let other = other as? ConstraintItem {
-            guard other.attributes == ConstraintAttributes.none ||
+            guard other.attributes == .none ||
                   other.attributes.layoutAttributes.count <= 1 ||
                   other.attributes.layoutAttributes == self.description.attributes.layoutAttributes ||
                   other.attributes == .edges && self.description.attributes == .margins ||
@@ -52,13 +52,13 @@ public class ConstraintMakerRelatable {
             related = other
             constant = 0.0
         } else if let other = other as? ConstraintView {
-            related = ConstraintItem(target: other, attributes: ConstraintAttributes.none)
+            related = ConstraintItem(target: other, attributes: .none)
             constant = 0.0
         } else if let other = other as? ConstraintConstantTarget {
-            related = ConstraintItem(target: nil, attributes: ConstraintAttributes.none)
+            related = ConstraintItem(target: nil, attributes: .none)
             constant = other
         } else if #available(iOS 9.0, OSX 10.11, *), let other = other as? ConstraintLayoutGuide {
-            related = ConstraintItem(target: other, attributes: ConstraintAttributes.none)
+            related = ConstraintItem(target: other, attributes: .none)
             constant = 0.0
         } else {
             fatalError("Invalid constraint. (\(file), \(line))")

--- a/Source/ConstraintMakerRelatable.swift
+++ b/Source/ConstraintMakerRelatable.swift
@@ -30,13 +30,13 @@
 
 public class ConstraintMakerRelatable {
     
-    internal let description: ConstraintDescription
+    let description: ConstraintDescription
     
-    internal init(_ description: ConstraintDescription) {
+    init(_ description: ConstraintDescription) {
         self.description = description
     }
     
-    internal func relatedTo(_ other: ConstraintRelatableTarget, relation: ConstraintRelation, file: String, line: UInt) -> ConstraintMakerEditable {
+    func relatedTo(_ other: ConstraintRelatableTarget, relation: ConstraintRelation, file: String, line: UInt) -> ConstraintMakerEditable {
         let related: ConstraintItem
         let constant: ConstraintConstantTarget
         

--- a/Source/ConstraintOffsetTarget.swift
+++ b/Source/ConstraintOffsetTarget.swift
@@ -48,7 +48,7 @@ extension CGFloat: ConstraintOffsetTarget {
 
 extension ConstraintOffsetTarget {
     
-    internal var constraintOffsetTargetValue: CGFloat {
+    var constraintOffsetTargetValue: CGFloat {
         let offset: CGFloat
         if let amount = self as? Float {
             offset = CGFloat(amount)

--- a/Source/ConstraintRelation.swift
+++ b/Source/ConstraintRelation.swift
@@ -28,12 +28,12 @@
 #endif
 
 
-internal enum ConstraintRelation : Int {
+enum ConstraintRelation : Int {
     case equal = 1
     case lessThanOrEqual
     case greaterThanOrEqual
     
-    internal var layoutRelation: LayoutRelation {
+    var layoutRelation: LayoutRelation {
         get {
             switch(self) {
             case .equal:

--- a/Source/ConstraintViewDSL.swift
+++ b/Source/ConstraintViewDSL.swift
@@ -91,9 +91,9 @@ public struct ConstraintViewDSL: ConstraintAttributesDSL {
         return self.view
     }
     
-    internal let view: ConstraintView
+    let view: ConstraintView
     
-    internal init(view: ConstraintView) {
+    init(view: ConstraintView) {
         self.view = view
         
     }

--- a/Source/LayoutConstraint.swift
+++ b/Source/LayoutConstraint.swift
@@ -39,11 +39,11 @@ public class LayoutConstraint : NSLayoutConstraint {
         }
     }
     
-    internal weak var constraint: Constraint? = nil
+    weak var constraint: Constraint? = nil
     
 }
 
-internal func ==(lhs: LayoutConstraint, rhs: LayoutConstraint) -> Bool {
+func ==(lhs: LayoutConstraint, rhs: LayoutConstraint) -> Bool {
     guard lhs.firstItem === rhs.firstItem &&
           lhs.secondItem === rhs.secondItem &&
           lhs.firstAttribute == rhs.firstAttribute &&

--- a/Source/LayoutConstraintItem.swift
+++ b/Source/LayoutConstraintItem.swift
@@ -41,13 +41,13 @@ extension ConstraintView : LayoutConstraintItem {
 
 extension LayoutConstraintItem {
     
-    internal func prepare() {
+    func prepare() {
         if let view = self as? ConstraintView {
             view.translatesAutoresizingMaskIntoConstraints = false
         }
     }
     
-    internal var superview: ConstraintView? {
+    var superview: ConstraintView? {
         if let view = self as? ConstraintView {
             return view.superview
         }
@@ -58,18 +58,18 @@ extension LayoutConstraintItem {
         
         return nil
     }
-    internal var constraints: [Constraint] {
+    var constraints: [Constraint] {
         return self.constraintsSet.allObjects as! [Constraint]
     }
     
-    internal func add(constraints: [Constraint]) {
+    func add(constraints: [Constraint]) {
         let constraintsSet = self.constraintsSet
         for constraint in constraints {
             constraintsSet.add(constraint)
         }
     }
     
-    internal func remove(constraints: [Constraint]) {
+    func remove(constraints: [Constraint]) {
         let constraintsSet = self.constraintsSet
         for constraint in constraints {
             constraintsSet.remove(constraint)


### PR DESCRIPTION
- Remove internal access contorl level bacause it is default access control level in Swift 4
> Default Access Levels
All entities in your code (with a few specific exceptions, as described later in this chapter) have a default access level of internal if you don’t specify an explicit access level yourself. As a result, in many cases you don’t need to specify an explicit access level in your code.

https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html

- Refactor ConstraintAttributes using enum's Dot syntax
```swift
// as is
return ConstraintItem(target: self.target, attributes: ConstraintAttributes.centerX)
// to be
return ConstraintItem(target: self.target, attributes: .centerX)
```