### PR TITLE
Add back Package.swift for SwiftPM compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version:5.0
+//
+//  SnapKit
+//
+//  Copyright (c) 2011-Present SnapKit Team - https://github.com/SnapKit
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+import PackageDescription
+
+let package = Package(
+    name: "SnapKit",
+    products: [
+        .library(name: "SnapKit", targets: ["SnapKit"]),
+    ],
+    targets: [
+        .target(name: "SnapKit", path: "Source"),
+        .testTarget(name: "SnapKitTests", dependencies: ["SnapKit"]),
+    ]
+)


### PR DESCRIPTION
reverts 477fffae4c37386285f78511ff4120f1f5324ff8

SnapKit was actually was compatible with SwiftPM since #501 was merged, this adds the file back