### PR TITLE
[EXC_BAD_ACCESS] Update LayoutConstraint == operator to support iOS 10 and higher changes

### DIFF
--- a/Source/LayoutConstraint.swift
+++ b/Source/LayoutConstraint.swift
@@ -44,14 +44,21 @@ public class LayoutConstraint : NSLayoutConstraint {
 }
 
 internal func ==(lhs: LayoutConstraint, rhs: LayoutConstraint) -> Bool {
-    guard lhs.firstItem === rhs.firstItem &&
-          lhs.secondItem === rhs.secondItem &&
-          lhs.firstAttribute == rhs.firstAttribute &&
-          lhs.secondAttribute == rhs.secondAttribute &&
-          lhs.relation == rhs.relation &&
-          lhs.priority == rhs.priority &&
-          lhs.multiplier == rhs.multiplier else {
-        return false
+    let areLayoutAnchorsEqual: Bool
+    if #available(iOS 10.0, OSXApplicationExtension 10.12, *) {
+        areLayoutAnchorsEqual = lhs.firstAnchor === rhs.firstAnchor &&
+            lhs.secondAnchor === rhs.secondAnchor
+    } else {
+        areLayoutAnchorsEqual = lhs.firstItem === rhs.firstItem &&
+            lhs.secondItem === rhs.secondItem &&
+            lhs.firstAttribute == rhs.firstAttribute &&
+            lhs.secondAttribute == rhs.secondAttribute
+    }
+    guard areLayoutAnchorsEqual &&
+        lhs.relation == rhs.relation &&
+        lhs.priority == rhs.priority &&
+        lhs.multiplier == rhs.multiplier else {
+            return false
     }
     return true
 }

--- a/Source/LayoutConstraint.swift
+++ b/Source/LayoutConstraint.swift
@@ -54,11 +54,8 @@ internal func ==(lhs: LayoutConstraint, rhs: LayoutConstraint) -> Bool {
             lhs.firstAttribute == rhs.firstAttribute &&
             lhs.secondAttribute == rhs.secondAttribute
     }
-    guard areLayoutAnchorsEqual &&
+    return areLayoutAnchorsEqual &&
         lhs.relation == rhs.relation &&
         lhs.priority == rhs.priority &&
-        lhs.multiplier == rhs.multiplier else {
-            return false
-    }
-    return true
+        lhs.multiplier == rhs.multiplier
 }

--- a/Tests/SnapKitTests/Tests.swift
+++ b/Tests/SnapKitTests/Tests.swift
@@ -580,4 +580,34 @@ class SnapKitTests: XCTestCase {
         let higherPriority: ConstraintPriority = ConstraintPriority.high.advanced(by: 1)
         XCTAssertEqual(higherPriority.value, highPriority.value + 1)
     }
+    
+    func testLayoutConstraintEqual() {
+        let view1 = View()
+        let view2 = View()
+        let layoutConstraint1 = LayoutConstraint(item: view1,
+                                                 attribute: .top,
+                                                 relatedBy: .lessThanOrEqual,
+                                                 toItem: view2,
+                                                 attribute: .bottom,
+                                                 multiplier: 2,
+                                                 constant: 30)
+        let layoutConstraint2 = LayoutConstraint(item: view1,
+                                                 attribute: .top,
+                                                 relatedBy: .lessThanOrEqual,
+                                                 toItem: view2,
+                                                 attribute: .bottom,
+                                                 multiplier: 2,
+                                                 constant: 30)
+        let layoutConstraint3 = LayoutConstraint(item: view1,
+                                                 attribute: .top,
+                                                 relatedBy: .lessThanOrEqual,
+                                                 toItem: view2,
+                                                 attribute: .bottom,
+                                                 multiplier: 1,
+                                                 constant: 50)
+        XCTAssertTrue(layoutConstraint1 == layoutConstraint2)
+        XCTAssertFalse(layoutConstraint1 == layoutConstraint3)
+        XCTAssertFalse(layoutConstraint2 == layoutConstraint3)
+    }
+    
 }


### PR DESCRIPTION
Hello SnapKit team,

Recently, we had a very weird `EXC_BAD_ACCESS (code=EXC_I386_GPFLT)` crash, that was happening on the updating of the constraints randomly but still quite often (maybe once every 4 times the screen was opened). 
The code was crashing on the guard statement of the `==` operator of the `LayoutConstraint` class. After further investigation, we found out that the crash is caused by the `firstItem` or `secondItem` fields of the `NSLayoutConstraint` of the `UIKit`. Digging into the documentation of this class, you can notice that those fields are `unowned(unsafe)`. 
The Apple comment says: 
```
/* accessors
     firstItem.firstAttribute {==,<=,>=} secondItem.secondAttribute * multiplier + constant
     Access to these properties is not recommended. Use the `firstAnchor` and `secondAnchor` properties instead.
     */
```
After replacing `firstItem.firstAttribute` and `secondItem.secondAttribute` with `firstAnchor` and `secondAnchor` the crashes disappeared.
You can see the fix of this issue above. Also, the test is prepared to make sure it works correctly on all the platforms.

Please let me know what you think!