### PR TITLE
Make ConstraintViewDSL content priorities nonmutating

### DIFF
--- a/Source/ConstraintViewDSL.swift
+++ b/Source/ConstraintViewDSL.swift
@@ -55,7 +55,7 @@ public struct ConstraintViewDSL: ConstraintAttributesDSL {
         get {
             return self.view.contentHuggingPriority(for: .horizontal).rawValue
         }
-        set {
+        nonmutating set {
             self.view.setContentHuggingPriority(LayoutPriority(rawValue: newValue), for: .horizontal)
         }
     }
@@ -64,7 +64,7 @@ public struct ConstraintViewDSL: ConstraintAttributesDSL {
         get {
             return self.view.contentHuggingPriority(for: .vertical).rawValue
         }
-        set {
+        nonmutating set {
             self.view.setContentHuggingPriority(LayoutPriority(rawValue: newValue), for: .vertical)
         }
     }
@@ -73,7 +73,7 @@ public struct ConstraintViewDSL: ConstraintAttributesDSL {
         get {
             return self.view.contentCompressionResistancePriority(for: .horizontal).rawValue
         }
-        set {
+        nonmutating set {
             self.view.setContentCompressionResistancePriority(LayoutPriority(rawValue: newValue), for: .horizontal)
         }
     }
@@ -82,7 +82,7 @@ public struct ConstraintViewDSL: ConstraintAttributesDSL {
         get {
             return self.view.contentCompressionResistancePriority(for: .vertical).rawValue
         }
-        set {
+        nonmutating set {
             self.view.setContentCompressionResistancePriority(LayoutPriority(rawValue: newValue), for: .vertical)
         }
     }


### PR DESCRIPTION
Hi.

`view.snp` is a computed struct property, and we can't change `content ... Priority` unless we make `var snp: ConstraintViewDSL`.
```swift
var snp = view.snp
snp.contentCompressionResistanceHorizontalPriority = 751
```

`nonmutating set` makes changes to content priorities much easier.
```swift
view.snp.contentCompressionResistanceHorizontalPriority = 751
```