### PR TITLE
Adds support for NSDirectionalEdgeInsets as an inset constant

### DIFF
--- a/SnapKit.xcodeproj/project.pbxproj
+++ b/SnapKit.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		2DBA080E1F1FAD66001CFED4 /* Typealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBA080D1F1FAD66001CFED4 /* Typealiases.swift */; };
+		7E1CB2AE227BB5520066B6C0 /* ConstraintDirectionalInsetTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1CB2AD227BB5520066B6C0 /* ConstraintDirectionalInsetTarget.swift */; };
+		7E1CB2B0227BBDF70066B6C0 /* ConstraintDirectionalInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1CB2AF227BBDF70066B6C0 /* ConstraintDirectionalInsets.swift */; };
 		EE235F5F1C5785BC00C08960 /* Debugging.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE235F5E1C5785BC00C08960 /* Debugging.swift */; };
 		EE235F6D1C5785C600C08960 /* Constraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE235F621C5785C600C08960 /* Constraint.swift */; };
 		EE235F701C5785C600C08960 /* ConstraintDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE235F631C5785C600C08960 /* ConstraintDescription.swift */; };
@@ -49,6 +51,8 @@
 /* Begin PBXFileReference section */
 		2DBA080D1F1FAD66001CFED4 /* Typealiases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typealiases.swift; sourceTree = "<group>"; };
 		537DCE9A1C35CD4100B5B899 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS9.1.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		7E1CB2AD227BB5520066B6C0 /* ConstraintDirectionalInsetTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstraintDirectionalInsetTarget.swift; sourceTree = "<group>"; };
+		7E1CB2AF227BBDF70066B6C0 /* ConstraintDirectionalInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstraintDirectionalInsets.swift; sourceTree = "<group>"; };
 		EE235F5E1C5785BC00C08960 /* Debugging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Debugging.swift; sourceTree = "<group>"; };
 		EE235F621C5785C600C08960 /* Constraint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constraint.swift; sourceTree = "<group>"; };
 		EE235F631C5785C600C08960 /* ConstraintDescription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstraintDescription.swift; sourceTree = "<group>"; };
@@ -172,6 +176,7 @@
 				EE235F911C5785CE00C08960 /* ConstraintMultiplierTarget.swift */,
 				EE235F921C5785CE00C08960 /* ConstraintOffsetTarget.swift */,
 				EE235F931C5785CE00C08960 /* ConstraintInsetTarget.swift */,
+				7E1CB2AD227BB5520066B6C0 /* ConstraintDirectionalInsetTarget.swift */,
 			);
 			name = Targets;
 			sourceTree = "<group>";
@@ -183,6 +188,7 @@
 				EE235F621C5785C600C08960 /* Constraint.swift */,
 				EE235F631C5785C600C08960 /* ConstraintDescription.swift */,
 				EE235F641C5785C600C08960 /* ConstraintInsets.swift */,
+				7E1CB2AF227BBDF70066B6C0 /* ConstraintDirectionalInsets.swift */,
 				EE235F651C5785C600C08960 /* ConstraintConfig.swift */,
 				EE235F661C5785C600C08960 /* ConstraintView.swift */,
 				EEF68FBB1D78653000980C26 /* ConstraintLayoutGuide.swift */,
@@ -372,6 +378,7 @@
 				EE235FB51C5785D400C08960 /* ConstraintMakerEditable.swift in Sources */,
 				EEF68FBC1D78653000980C26 /* ConstraintLayoutGuide.swift in Sources */,
 				EE235FAC1C5785D400C08960 /* ConstraintMaker.swift in Sources */,
+				7E1CB2AE227BB5520066B6C0 /* ConstraintDirectionalInsetTarget.swift in Sources */,
 				EE6087751E4F133E0029CF84 /* ConstraintPriority.swift in Sources */,
 				EE235F941C5785CE00C08960 /* ConstraintRelatableTarget.swift in Sources */,
 				EEF68FA61D784A5300980C26 /* ConstraintDSL.swift in Sources */,
@@ -387,6 +394,7 @@
 				EE6898CB1DA7B3A100D47F33 /* LayoutConstraintItem.swift in Sources */,
 				EE235FB21C5785D400C08960 /* ConstraintMakerPriortizable.swift in Sources */,
 				EE235F8B1C5785C600C08960 /* LayoutConstraint.swift in Sources */,
+				7E1CB2B0227BBDF70066B6C0 /* ConstraintDirectionalInsets.swift in Sources */,
 				EE235FA31C5785CE00C08960 /* ConstraintInsetTarget.swift in Sources */,
 				EE235F9D1C5785CE00C08960 /* ConstraintMultiplierTarget.swift in Sources */,
 				EE235FC01C5785DC00C08960 /* ConstraintViewDSL.swift in Sources */,

--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -219,6 +219,15 @@ public final class Constraint {
         return self
     }
 
+    #if os(iOS) || os(tvOS)
+    @discardableResult
+    @available(iOS 11.0, tvOS 11.0, *)
+    public func update(inset: ConstraintDirectionalInsetTarget) -> Constraint {
+      self.constant = inset.constraintDirectionalInsetTargetValue
+      return self
+    }
+    #endif
+
     @discardableResult
     public func update(priority: ConstraintPriorityTarget) -> Constraint {
         self.priority = priority.constraintPriorityTargetValue

--- a/Source/ConstraintConstantTarget.swift
+++ b/Source/ConstraintConstantTarget.swift
@@ -40,6 +40,12 @@ extension CGSize: ConstraintConstantTarget {
 extension ConstraintInsets: ConstraintConstantTarget {
 }
 
+#if os(iOS) || os(tvOS)
+@available(iOS 11.0, tvOS 11.0, *)
+extension ConstraintDirectionalInsets: ConstraintConstantTarget {
+}
+#endif
+
 extension ConstraintConstantTarget {
     
     internal func constraintConstantTargetValueFor(layoutAttribute: LayoutAttribute) -> CGFloat {
@@ -165,6 +171,42 @@ extension ConstraintConstantTarget {
             #endif
         }
         
+        #if os(iOS) || os(tvOS)
+            if #available(iOS 11.0, tvOS 11.0, *), let value = self as? ConstraintDirectionalInsets {
+                switch layoutAttribute {
+                case .left, .leftMargin:
+                  return (ConstraintConfig.interfaceLayoutDirection == .leftToRight) ? value.leading : value.trailing
+                case .top, .topMargin, .firstBaseline:
+                    return value.top
+                case .right, .rightMargin:
+                  return (ConstraintConfig.interfaceLayoutDirection == .leftToRight) ? -value.trailing : -value.leading
+                case .bottom, .bottomMargin, .lastBaseline:
+                    return -value.bottom
+                case .leading, .leadingMargin:
+                    return value.leading
+                case .trailing, .trailingMargin:
+                    return -value.trailing
+                case .centerX, .centerXWithinMargins:
+                    return (value.leading - value.trailing) / 2
+                case .centerY, .centerYWithinMargins:
+                    return (value.top - value.bottom) / 2
+                case .width:
+                    return -(value.leading + value.trailing)
+                case .height:
+                    return -(value.top + value.bottom)
+                case .notAnAttribute:
+                    return 0.0
+                #if swift(>=5.0)
+                @unknown default:
+                    return 0.0
+                #else
+                default:
+                    return 0.0
+                #endif
+                }
+            }
+        #endif
+
         return 0.0
     }
     

--- a/Source/ConstraintDirectionalInsetTarget.swift
+++ b/Source/ConstraintDirectionalInsetTarget.swift
@@ -22,51 +22,28 @@
 //  THE SOFTWARE.
 
 #if os(iOS) || os(tvOS)
-    import UIKit
+import UIKit
 #else
-    import AppKit
+import AppKit
 #endif
-
-
-public protocol ConstraintRelatableTarget {
-}
-
-extension Int: ConstraintRelatableTarget {
-}
-
-extension UInt: ConstraintRelatableTarget {
-}
-
-extension Float: ConstraintRelatableTarget {
-}
-
-extension Double: ConstraintRelatableTarget {
-}
-
-extension CGFloat: ConstraintRelatableTarget {
-}
-
-extension CGSize: ConstraintRelatableTarget {
-}
-
-extension CGPoint: ConstraintRelatableTarget {
-}
-
-extension ConstraintInsets: ConstraintRelatableTarget {
-}
 
 #if os(iOS) || os(tvOS)
+public protocol ConstraintDirectionalInsetTarget: ConstraintConstantTarget {
+}
+
 @available(iOS 11.0, tvOS 11.0, *)
-extension ConstraintDirectionalInsets: ConstraintRelatableTarget {
+extension ConstraintDirectionalInsets: ConstraintDirectionalInsetTarget {
+}
+
+extension ConstraintDirectionalInsetTarget {
+
+  @available(iOS 11.0, tvOS 11.0, *)
+  internal var constraintDirectionalInsetTargetValue: ConstraintDirectionalInsets {
+    if let amount = self as? ConstraintDirectionalInsets {
+      return amount
+    } else {
+      return ConstraintDirectionalInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+    }
+  }
 }
 #endif
-
-extension ConstraintItem: ConstraintRelatableTarget {
-}
-
-extension ConstraintView: ConstraintRelatableTarget {
-}
-
-@available(iOS 9.0, OSX 10.11, *)
-extension ConstraintLayoutGuide: ConstraintRelatableTarget {
-}

--- a/Source/ConstraintDirectionalInsets.swift
+++ b/Source/ConstraintDirectionalInsets.swift
@@ -28,45 +28,7 @@
 #endif
 
 
-public protocol ConstraintRelatableTarget {
-}
-
-extension Int: ConstraintRelatableTarget {
-}
-
-extension UInt: ConstraintRelatableTarget {
-}
-
-extension Float: ConstraintRelatableTarget {
-}
-
-extension Double: ConstraintRelatableTarget {
-}
-
-extension CGFloat: ConstraintRelatableTarget {
-}
-
-extension CGSize: ConstraintRelatableTarget {
-}
-
-extension CGPoint: ConstraintRelatableTarget {
-}
-
-extension ConstraintInsets: ConstraintRelatableTarget {
-}
-
 #if os(iOS) || os(tvOS)
-@available(iOS 11.0, tvOS 11.0, *)
-extension ConstraintDirectionalInsets: ConstraintRelatableTarget {
-}
+    @available(iOS 11.0, tvOS 11.0, *)
+    public typealias ConstraintDirectionalInsets = NSDirectionalEdgeInsets
 #endif
-
-extension ConstraintItem: ConstraintRelatableTarget {
-}
-
-extension ConstraintView: ConstraintRelatableTarget {
-}
-
-@available(iOS 9.0, OSX 10.11, *)
-extension ConstraintLayoutGuide: ConstraintRelatableTarget {
-}

--- a/Source/ConstraintMakerEditable.swift
+++ b/Source/ConstraintMakerEditable.swift
@@ -53,4 +53,12 @@ public class ConstraintMakerEditable: ConstraintMakerPriortizable {
         return self
     }
     
+    #if os(iOS) || os(tvOS)
+    @discardableResult
+    @available(iOS 11.0, tvOS 11.0, *)
+    public func inset(_ amount: ConstraintDirectionalInsetTarget) -> ConstraintMakerEditable {
+        self.description.constant = amount.constraintDirectionalInsetTargetValue
+        return self
+    }
+    #endif
 }

--- a/Tests/SnapKitTests/Tests.swift
+++ b/Tests/SnapKitTests/Tests.swift
@@ -413,6 +413,90 @@ class SnapKitTests: XCTestCase {
         XCTAssertEqual(constraints[3].constant, -25, "Should be -25")
     }
     
+    #if os(iOS) || os(tvOS)
+    @available(iOS 11.0, tvOS 11.0, *)
+    func testConstraintDirectionalInsetsAsImpliedEqualToConstraints() {
+        let view = View()
+        self.container.addSubview(view)
+
+        view.snp.makeConstraints { (make) -> Void in
+            make.top.leading.bottom.trailing.equalTo(self.container).inset(ConstraintDirectionalInsets(top: 25, leading: 25, bottom: 25, trailing: 25))
+        }
+
+        XCTAssertEqual(self.container.snp_constraints.count, 4, "Should have 4 constraints")
+
+
+        let constraints = (self.container.snp_constraints as! [NSLayoutConstraint]).sorted { $0.firstAttribute.rawValue < $1.firstAttribute.rawValue }
+
+        let verify: (NSLayoutConstraint, NSLayoutConstraint.Attribute, CGFloat) -> Void = { constraint, attribute, constant in
+          XCTAssertEqual(constraint.firstAttribute, attribute, "First attribute \(constraint.firstAttribute.rawValue) is not \(attribute.rawValue)")
+          XCTAssertEqual(constraint.secondAttribute, attribute, "Second attribute \(constraint.secondAttribute.rawValue) is not \(attribute.rawValue)")
+          XCTAssertEqual(constraint.constant, constant, "Attribute \(attribute.rawValue) should have constant \(constant)")
+        }
+
+        verify(constraints[0], .top, 25)
+        verify(constraints[1], .bottom, -25)
+        verify(constraints[2], .leading, 25)
+        verify(constraints[3], .trailing, -25)
+    }
+    #endif
+
+    #if os(iOS) || os(tvOS)
+    @available(iOS 11.0, tvOS 11.0, *)
+    func testConstraintDirectionalInsetsAsConstraintsConstant() {
+        let view = View()
+        self.container.addSubview(view)
+
+        view.snp.makeConstraints { (make) -> Void in
+            make.top.leading.bottom.trailing.equalTo(self.container).inset(ConstraintDirectionalInsets(top: 25, leading: 25, bottom: 25, trailing: 25))
+        }
+
+        XCTAssertEqual(self.container.snp_constraints.count, 4, "Should have 4 constraints")
+
+
+        let constraints = (self.container.snp_constraints as! [NSLayoutConstraint]).sorted { $0.firstAttribute.rawValue < $1.firstAttribute.rawValue }
+
+        let verify: (NSLayoutConstraint, NSLayoutConstraint.Attribute, CGFloat) -> Void = { constraint, attribute, constant in
+            XCTAssertEqual(constraint.firstAttribute, attribute, "First attribute \(constraint.firstAttribute.rawValue) is not \(attribute.rawValue)")
+            XCTAssertEqual(constraint.secondAttribute, attribute, "Second attribute \(constraint.secondAttribute.rawValue) is not \(attribute.rawValue)")
+            XCTAssertEqual(constraint.constant, constant, "Attribute \(attribute.rawValue) should have constant \(constant)")
+        }
+
+        verify(constraints[0], .top, 25)
+        verify(constraints[1], .bottom, -25)
+        verify(constraints[2], .leading, 25)
+        verify(constraints[3], .trailing, -25)
+    }
+    #endif
+
+    #if os(iOS) || os(tvOS)
+    @available(iOS 11.0, tvOS 11.0, *)
+    func testConstraintDirectionalInsetsFallBackForNonDirectionalConstraints() {
+        let view = View()
+        self.container.addSubview(view)
+
+        view.snp.makeConstraints { (make) -> Void in
+            make.edges.equalTo(self.container).inset(ConstraintDirectionalInsets(top: 25, leading: 25, bottom: 25, trailing: 25))
+        }
+
+        XCTAssertEqual(self.container.snp_constraints.count, 4, "Should have 4 constraints")
+
+
+        let constraints = (self.container.snp_constraints as! [NSLayoutConstraint]).sorted { $0.firstAttribute.rawValue < $1.firstAttribute.rawValue }
+
+        let verify: (NSLayoutConstraint, NSLayoutConstraint.Attribute, CGFloat) -> Void = { constraint, attribute, constant in
+            XCTAssertEqual(constraint.firstAttribute, attribute, "First attribute \(constraint.firstAttribute.rawValue) is not \(attribute.rawValue)")
+            XCTAssertEqual(constraint.secondAttribute, attribute, "Second attribute \(constraint.secondAttribute.rawValue) is not \(attribute.rawValue)")
+            XCTAssertEqual(constraint.constant, constant, "Attribute \(attribute.rawValue) should have constant \(constant)")
+        }
+
+        verify(constraints[0], .left, 25)
+        verify(constraints[1], .right, -25)
+        verify(constraints[2], .top, 25)
+        verify(constraints[3], .bottom, -25)
+    }
+    #endif
+
     func testSizeConstraints() {
         let view = View()
         self.container.addSubview(view)


### PR DESCRIPTION
This change adds support for `NSDirectionalEdgeInsets` as a constant target.

Introduced in iOS 11 and tvOS 11, this type behaves similarly to `UIEdgeInsets` with the exception that it accounts for right-to-left rendering.

That is, instead of the `top, left, bottom, right` fields in `UIEdgeInsets`, `NSDirectionalEdgeInsets` has `top, leading, bottom, trailing`.