### PR TITLE
Adds two new compositions – DirectionalEdges and DirectionalMargins

### DIFF
--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -129,6 +129,32 @@ public final class Constraint {
                         default:
                             fatalError()
                         }
+                    } else if self.from.attributes == .directionalEdges && self.to.attributes == .directionalMargins {
+                      switch layoutFromAttribute {
+                      case .leading:
+                        layoutToAttribute = .leadingMargin
+                      case .trailing:
+                        layoutToAttribute = .trailingMargin
+                      case .top:
+                        layoutToAttribute = .topMargin
+                      case .bottom:
+                        layoutToAttribute = .bottomMargin
+                      default:
+                        fatalError()
+                      }
+                    } else if self.from.attributes == .directionalMargins && self.to.attributes == .directionalEdges {
+                      switch layoutFromAttribute {
+                      case .leadingMargin:
+                        layoutToAttribute = .leading
+                      case .trailingMargin:
+                        layoutToAttribute = .trailing
+                      case .topMargin:
+                        layoutToAttribute = .top
+                      case .bottomMargin:
+                        layoutToAttribute = .bottom
+                      default:
+                        fatalError()
+                      }
                     } else if self.from.attributes == self.to.attributes {
                         layoutToAttribute = layoutFromAttribute
                     } else {

--- a/Source/ConstraintAttributes.swift
+++ b/Source/ConstraintAttributes.swift
@@ -107,6 +107,9 @@ internal struct ConstraintAttributes : OptionSet, ExpressibleByIntegerLiteral {
     internal static var margins: ConstraintAttributes { return 61440 }
     
     @available(iOS 8.0, *)
+    internal static var directionalMargins: ConstraintAttributes { return 245760 }
+
+    @available(iOS 8.0, *)
     internal static var centerWithinMargins: ConstraintAttributes { return 786432 }
     
     internal var layoutAttributes:[LayoutAttribute] {

--- a/Source/ConstraintAttributes.swift
+++ b/Source/ConstraintAttributes.swift
@@ -99,6 +99,7 @@ internal struct ConstraintAttributes : OptionSet, ExpressibleByIntegerLiteral {
     // aggregates
     
     internal static var edges: ConstraintAttributes { return 15 }
+    internal static var directionalEdges: ConstraintAttributes { return 58 }
     internal static var size: ConstraintAttributes { return 192 }
     internal static var center: ConstraintAttributes { return 768 }
     

--- a/Source/ConstraintDSL.swift
+++ b/Source/ConstraintDSL.swift
@@ -182,6 +182,11 @@ extension ConstraintAttributesDSL {
     }
     
     @available(iOS 8.0, *)
+    public var directionalMargins: ConstraintItem {
+      return ConstraintItem(target: self.target, attributes: ConstraintAttributes.directionalMargins)
+    }
+
+    @available(iOS 8.0, *)
     public var centerWithinMargins: ConstraintItem {
         return ConstraintItem(target: self.target, attributes: ConstraintAttributes.centerWithinMargins)
     }

--- a/Source/ConstraintDSL.swift
+++ b/Source/ConstraintDSL.swift
@@ -98,7 +98,7 @@ extension ConstraintBasicAttributesDSL {
     public var edges: ConstraintItem {
         return ConstraintItem(target: self.target, attributes: ConstraintAttributes.edges)
     }
-
+    
     public var directionalEdges: ConstraintItem {
       return ConstraintItem(target: self.target, attributes: ConstraintAttributes.directionalEdges)
     }

--- a/Source/ConstraintDSL.swift
+++ b/Source/ConstraintDSL.swift
@@ -98,7 +98,11 @@ extension ConstraintBasicAttributesDSL {
     public var edges: ConstraintItem {
         return ConstraintItem(target: self.target, attributes: ConstraintAttributes.edges)
     }
-    
+
+    public var directionalEdges: ConstraintItem {
+      return ConstraintItem(target: self.target, attributes: ConstraintAttributes.directionalEdges)
+    }
+
     public var size: ConstraintItem {
         return ConstraintItem(target: self.target, attributes: ConstraintAttributes.size)
     }

--- a/Source/ConstraintMaker.swift
+++ b/Source/ConstraintMaker.swift
@@ -126,6 +126,9 @@ public class ConstraintMaker {
     public var edges: ConstraintMakerExtendable {
         return self.makeExtendableWithAttributes(.edges)
     }
+    public var directionalEdges: ConstraintMakerExtendable {
+        return self.makeExtendableWithAttributes(.directionalEdges)
+    }
     public var size: ConstraintMakerExtendable {
         return self.makeExtendableWithAttributes(.size)
     }

--- a/Source/ConstraintMaker.swift
+++ b/Source/ConstraintMaker.swift
@@ -142,6 +142,11 @@ public class ConstraintMaker {
     }
     
     @available(iOS 8.0, *)
+    public var directionalMargins: ConstraintMakerExtendable {
+        return self.makeExtendableWithAttributes(.directionalMargins)
+    }
+
+    @available(iOS 8.0, *)
     public var centerWithinMargins: ConstraintMakerExtendable {
         return self.makeExtendableWithAttributes(.centerWithinMargins)
     }

--- a/Source/ConstraintMakerExtendable.swift
+++ b/Source/ConstraintMakerExtendable.swift
@@ -149,6 +149,10 @@ public class ConstraintMakerExtendable: ConstraintMakerRelatable {
         self.description.attributes += .edges
         return self
     }
+    public var directionalEdges: ConstraintMakerExtendable {
+        self.description.attributes += .directionalEdges
+        return self
+    }
     public var size: ConstraintMakerExtendable {
         self.description.attributes += .size
         return self

--- a/Source/ConstraintMakerExtendable.swift
+++ b/Source/ConstraintMakerExtendable.swift
@@ -165,6 +165,12 @@ public class ConstraintMakerExtendable: ConstraintMakerRelatable {
     }
     
     @available(iOS 8.0, *)
+    public var directionalMargins: ConstraintMakerExtendable {
+      self.description.attributes += .directionalMargins
+      return self
+    }
+
+    @available(iOS 8.0, *)
     public var centerWithinMargins: ConstraintMakerExtendable {
         self.description.attributes += .centerWithinMargins
         return self

--- a/Source/ConstraintMakerRelatable.swift
+++ b/Source/ConstraintMakerRelatable.swift
@@ -45,9 +45,9 @@ public class ConstraintMakerRelatable {
                   other.attributes.layoutAttributes.count <= 1 ||
                   other.attributes.layoutAttributes == self.description.attributes.layoutAttributes ||
                   other.attributes == .edges && self.description.attributes == .margins ||
-                  other.attributes == .directionalEdges && self.description.attributes == .margins ||
-                  other.attributes == .margins && self.description.attributes == .edges || 
-                  other.attributes == .margins && self.description.attributes == .directionalEdges else {
+                  other.attributes == .margins && self.description.attributes == .edges ||
+                  other.attributes == .directionalEdges && self.description.attributes == .directionalMargins ||
+                  other.attributes == .directionalMargins && self.description.attributes == .directionalEdges else {
                 fatalError("Cannot constraint to multiple non identical attributes. (\(file), \(line))");
             }
             

--- a/Source/ConstraintMakerRelatable.swift
+++ b/Source/ConstraintMakerRelatable.swift
@@ -45,7 +45,9 @@ public class ConstraintMakerRelatable {
                   other.attributes.layoutAttributes.count <= 1 ||
                   other.attributes.layoutAttributes == self.description.attributes.layoutAttributes ||
                   other.attributes == .edges && self.description.attributes == .margins ||
-                  other.attributes == .margins && self.description.attributes == .edges else {
+                  other.attributes == .directionalEdges && self.description.attributes == .margins ||
+                  other.attributes == .margins && self.description.attributes == .edges || 
+                  other.attributes == .margins && self.description.attributes == .directionalEdges else {
                 fatalError("Cannot constraint to multiple non identical attributes. (\(file), \(line))");
             }
             

--- a/Tests/SnapKitTests/Tests.swift
+++ b/Tests/SnapKitTests/Tests.swift
@@ -492,7 +492,7 @@ class SnapKitTests: XCTestCase {
         XCTAssert(toAttributes == [.top, .left, .bottom, .right])
     }
 
-    func testDirectionalEdgesToDirectionalEdgesEdges() {
+    func testDirectionalEdgesToDirectionalEdges() {
         var fromAttributes = Set<LayoutAttribute>()
         var toAttributes = Set<LayoutAttribute>()
         
@@ -555,7 +555,7 @@ class SnapKitTests: XCTestCase {
         
     }
 
-    func testDirectionalEdgesToMargins() {
+    func testDirectionalEdgesToDirectionalMargins() {
         var fromAttributes = Set<LayoutAttribute>()
         var toAttributes = Set<LayoutAttribute>()
         
@@ -563,7 +563,7 @@ class SnapKitTests: XCTestCase {
         self.container.addSubview(view)
         
         view.snp.remakeConstraints { (make) -> Void in
-            make.directionalEdges.equalTo(self.container.snp.margins)
+            make.directionalEdges.equalTo(self.container.snp.directionalMargins)
         }
         
         XCTAssertEqual(self.container.snp_constraints.count, 4, "Should have 4 constraints")
@@ -580,7 +580,7 @@ class SnapKitTests: XCTestCase {
         toAttributes.removeAll()
         
         view.snp.remakeConstraints { (make) -> Void in
-            make.margins.equalTo(self.container.snp.directionalEdges)
+            make.directionalMargins.equalTo(self.container.snp.directionalEdges)
         }
         
         XCTAssertEqual(self.container.snp_constraints.count, 4, "Should have 4 constraints")

--- a/Tests/SnapKitTests/Tests.swift
+++ b/Tests/SnapKitTests/Tests.swift
@@ -491,6 +491,28 @@ class SnapKitTests: XCTestCase {
         XCTAssert(fromAttributes == [.top, .left, .bottom, .right])
         XCTAssert(toAttributes == [.top, .left, .bottom, .right])
     }
+
+    func testDirectionalEdgesToDirectionalEdgesEdges() {
+        var fromAttributes = Set<LayoutAttribute>()
+        var toAttributes = Set<LayoutAttribute>()
+        
+        let view = View()
+        self.container.addSubview(view)
+        
+        view.snp.remakeConstraints { (make) -> Void in
+            make.directionalEdges.equalTo(self.container.snp.directionalEdges)
+        }
+        
+        XCTAssertEqual(self.container.snp_constraints.count, 4, "Should have 4 constraints")
+        
+        for constraint in (container.snp_constraints as! [NSLayoutConstraint]) {
+            fromAttributes.insert(constraint.firstAttribute)
+            toAttributes.insert(constraint.secondAttribute)
+        }
+        
+        XCTAssert(fromAttributes == [.top, .leading, .bottom, .trailing])
+        XCTAssert(toAttributes == [.top, .leading, .bottom, .trailing])
+    }
     
     #if os(iOS) || os(tvOS)
     func testEdgesToMargins() {
@@ -530,6 +552,46 @@ class SnapKitTests: XCTestCase {
         
         XCTAssert(toAttributes == [.top, .left, .bottom, .right])
         XCTAssert(fromAttributes == [.topMargin, .leftMargin, .bottomMargin, .rightMargin])
+        
+    }
+
+    func testDirectionalEdgesToMargins() {
+        var fromAttributes = Set<LayoutAttribute>()
+        var toAttributes = Set<LayoutAttribute>()
+        
+        let view = View()
+        self.container.addSubview(view)
+        
+        view.snp.remakeConstraints { (make) -> Void in
+            make.directionalEdges.equalTo(self.container.snp.margins)
+        }
+        
+        XCTAssertEqual(self.container.snp_constraints.count, 4, "Should have 4 constraints")
+        
+        for constraint in (container.snp_constraints as! [NSLayoutConstraint]) {
+            fromAttributes.insert(constraint.firstAttribute)
+            toAttributes.insert(constraint.secondAttribute)
+        }
+        
+        XCTAssert(fromAttributes == [.top, .leading, .bottom, .trailing])
+        XCTAssert(toAttributes == [.topMargin, .leadingMargin, .bottomMargin, .trailingMargin])
+        
+        fromAttributes.removeAll()
+        toAttributes.removeAll()
+        
+        view.snp.remakeConstraints { (make) -> Void in
+            make.margins.equalTo(self.container.snp.directionalEdges)
+        }
+        
+        XCTAssertEqual(self.container.snp_constraints.count, 4, "Should have 4 constraints")
+        
+        for constraint in (container.snp_constraints as! [NSLayoutConstraint]) {
+            fromAttributes.insert(constraint.firstAttribute)
+            toAttributes.insert(constraint.secondAttribute)
+        }
+        
+        XCTAssert(toAttributes == [.top, .leading, .bottom, .trailing])
+        XCTAssert(fromAttributes == [.topMargin, .leadingMargin, .bottomMargin, .trailingMargin])
         
     }
     


### PR DESCRIPTION
This PR introduces two new RTL-friendly compositions, `directionalEdges` and `directionalMargins`. These compositions behave identically to `edges` and `margins`, with the distinction of using `leading` and `trailing` instead of `left` and `right`.

**`DirectionalEdges`**
`[.top, .leading, .bottom, .trailing]`

**`DirectionalMargins`**
`[.topMargin, .leadingMargin, .bottomMargin, .trailingMargin]`
