### PR TITLE
Add background color to Quick Start box in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ SnapKit is a DSL to make Auto Layout easy on both iOS and OS X.
 [![Cocoapods Compatible](https://img.shields.io/cocoapods/v/SnapKit.svg)](https://cocoapods.org/pods/SnapKit)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
-#### ⚠️ **To use with Swift 4.x please ensure you are using >= 4.0.0** ⚠️ 
-#### ⚠️ **To use with Swift 5.x please ensure you are using >= 5.0.0** ⚠️ 
+#### ⚠️ **To use with Swift 4.x please ensure you are using >= 4.0.0** ⚠️
+#### ⚠️ **To use with Swift 5.x please ensure you are using >= 5.0.0** ⚠️
 
 ## Contents
 
@@ -105,6 +105,7 @@ class MyViewController: UIViewController {
         super.viewDidLoad()
 
         self.view.addSubview(box)
+        box.backgroundColor = .green
         box.snp.makeConstraints { (make) -> Void in
            make.width.height.equalTo(50)
            make.center.equalTo(self.view)


### PR DESCRIPTION
Having followed the guide to setting things up I added the code from the code snippet of the `Quick Start` section of the readme. I could not see the view that the code was referring to. 

Adding a background color such as `box.backgroundColor = .green` before the constraint setup allowed me to see the view that was added.

I think updating the readme with the above line might help others in future.

| Before | After |
|---|---|
| <img width="584" alt="Screenshot 2019-07-29 at 09 21 13" src="https://user-images.githubusercontent.com/32336260/62032696-3ca9d880-b1e2-11e9-9307-1c3d43f1e2bd.png"> | <img width="584" alt="Screenshot 2019-07-29 at 09 19 43" src="https://user-images.githubusercontent.com/32336260/62032652-2439be00-b1e2-11e9-82ef-abe9f61b6239.png"> |
