### PR TITLE
Add Convenience ConstraintItems for dimensional edges

### DIFF
--- a/Source/ConstraintAttributes.swift
+++ b/Source/ConstraintAttributes.swift
@@ -99,7 +99,11 @@ internal struct ConstraintAttributes : OptionSet, ExpressibleByIntegerLiteral {
     // aggregates
     
     internal static var edges: ConstraintAttributes { return 15 }
+    internal static var horizontalEdges: ConstraintAttributes { return 5 }
+    internal static var verticalEdges: ConstraintAttributes { return 10 }
     internal static var directionalEdges: ConstraintAttributes { return 58 }
+    internal static var directionalHorizontalEdges: ConstraintAttributes { return 48 }
+    internal static var directionalVerticalEdges: ConstraintAttributes { return 10 }
     internal static var size: ConstraintAttributes { return 192 }
     internal static var center: ConstraintAttributes { return 768 }
     

--- a/Source/ConstraintDSL.swift
+++ b/Source/ConstraintDSL.swift
@@ -103,6 +103,22 @@ extension ConstraintBasicAttributesDSL {
       return ConstraintItem(target: self.target, attributes: ConstraintAttributes.directionalEdges)
     }
 
+    public var horizontalEdges: ConstraintItem {
+        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.horizontalEdges)
+    }
+
+    public var verticalEdges: ConstraintItem {
+        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.verticalEdges)
+    }
+
+    public var directionalHorizontalEdges: ConstraintItem {
+        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.directionalHorizontalEdges)
+    }
+
+    public var directionalVerticalEdges: ConstraintItem {
+        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.directionalVerticalEdges)
+    }
+
     public var size: ConstraintItem {
         return ConstraintItem(target: self.target, attributes: ConstraintAttributes.size)
     }

--- a/Source/ConstraintMaker.swift
+++ b/Source/ConstraintMaker.swift
@@ -126,8 +126,20 @@ public class ConstraintMaker {
     public var edges: ConstraintMakerExtendable {
         return self.makeExtendableWithAttributes(.edges)
     }
+    public var horizontalEdges: ConstraintMakerExtendable {
+        return self.makeExtendableWithAttributes(.horizontalEdges)
+    }
+    public var verticalEdges: ConstraintMakerExtendable {
+        return self.makeExtendableWithAttributes(.verticalEdges)
+    }
     public var directionalEdges: ConstraintMakerExtendable {
         return self.makeExtendableWithAttributes(.directionalEdges)
+    }
+    public var directionalHorizontalEdges: ConstraintMakerExtendable {
+        return self.makeExtendableWithAttributes(.directionalHorizontalEdges)
+    }
+    public var directionalVerticalEdges: ConstraintMakerExtendable {
+        return self.makeExtendableWithAttributes(.directionalVerticalEdges)
     }
     public var size: ConstraintMakerExtendable {
         return self.makeExtendableWithAttributes(.size)

--- a/Source/ConstraintMakerExtendable.swift
+++ b/Source/ConstraintMakerExtendable.swift
@@ -149,8 +149,24 @@ public class ConstraintMakerExtendable: ConstraintMakerRelatable {
         self.description.attributes += .edges
         return self
     }
+    public var horizontalEdges: ConstraintMakerExtendable {
+        self.description.attributes += .horizontalEdges
+        return self
+    }
+    public var verticalEdges: ConstraintMakerExtendable {
+        self.description.attributes += .verticalEdges
+        return self
+    }
     public var directionalEdges: ConstraintMakerExtendable {
         self.description.attributes += .directionalEdges
+        return self
+    }
+    public var directionalHorizontalEdges: ConstraintMakerExtendable {
+        self.description.attributes += .directionalHorizontalEdges
+        return self
+    }
+    public var directionalVerticalEdges: ConstraintMakerExtendable {
+        self.description.attributes += .directionalVerticalEdges
         return self
     }
     public var size: ConstraintMakerExtendable {

--- a/Tests/SnapKitTests/Tests.swift
+++ b/Tests/SnapKitTests/Tests.swift
@@ -59,6 +59,46 @@ class SnapKitTests: XCTestCase {
         XCTAssertEqual(self.container.snp_constraints.count, 6, "Should have 6 constraints installed")
         
     }
+
+    func testHorizontalVerticalEdges() {
+        let v1 = View()
+        self.container.addSubview(v1)
+
+        v1.snp.makeConstraints { (make) -> Void in
+            make.verticalEdges.equalToSuperview()
+            make.horizontalEdges.equalToSuperview()
+            return
+        }
+
+        XCTAssertEqual(self.container.snp_constraints.count, 4, "Should have 4 constraints installed")
+
+        XCTAssertTrue(container.constraints.count == 4)
+        XCTAssertTrue(container.constraints.allSatisfy { $0.firstItem === v1 && $0.secondItem === v1.superview })
+        XCTAssertNotNil(container.constraints.first { $0.firstAttribute == .left && $0.secondAttribute == .left })
+        XCTAssertNotNil(container.constraints.first { $0.firstAttribute == .right && $0.secondAttribute == .right })
+        XCTAssertNotNil(container.constraints.first { $0.firstAttribute == .top && $0.secondAttribute == .top })
+        XCTAssertNotNil(container.constraints.first { $0.firstAttribute == .bottom && $0.secondAttribute == .bottom })
+    }
+
+    func testHorizontalVerticalDirectionalEdges() {
+        let v1 = View()
+        self.container.addSubview(v1)
+
+        v1.snp.makeConstraints { (make) -> Void in
+            make.directionalVerticalEdges.equalToSuperview()
+            make.directionalHorizontalEdges.equalToSuperview()
+            return
+        }
+
+        XCTAssertEqual(self.container.snp_constraints.count, 4, "Should have 4 constraints installed")
+
+        XCTAssertTrue(container.constraints.count == 4)
+        XCTAssertTrue(container.constraints.allSatisfy { $0.firstItem === v1 && $0.secondItem === v1.superview })
+        XCTAssertNotNil(container.constraints.first { $0.firstAttribute == .leading && $0.secondAttribute == .leading })
+        XCTAssertNotNil(container.constraints.first { $0.firstAttribute == .trailing && $0.secondAttribute == .trailing })
+        XCTAssertNotNil(container.constraints.first { $0.firstAttribute == .top && $0.secondAttribute == .top })
+        XCTAssertNotNil(container.constraints.first { $0.firstAttribute == .bottom && $0.secondAttribute == .bottom })
+    }
     
     func testGuideMakeConstraints() {
         guard #available(iOS 9.0, OSX 10.11, *) else { return }


### PR DESCRIPTION
This PR adds the ConstraintItems `horizontalEdges`, `verticalEdges`, `directionalHorizontalEdges` and `directionalVerticalEdges` as convenience items to express left+right, top+bottom or leading+trailing.

I've been using these shortcuts for some time now in several projects to conveniently express something like 'Pin this view to the left and right edge of the superview':

```
subview.snp.makeConstraints { make in
    make.horizontalEdges.equalToSuperview()
}
```

This is very useful in cases where you don't want to pin all edges of a view to those of another view using `.edges.equalTo(...)`, but still don't want to type a lot of code to pin specific dimensional edges.

I've also added comprehensive UnitTesting for these new Items.