### PR TITLE
Add equalToSystemSpacingBelow relatable

### DIFF
--- a/Sources/ConstraintMakerRelatable.swift
+++ b/Sources/ConstraintMakerRelatable.swift
@@ -73,6 +73,25 @@ public class ConstraintMakerRelatable {
         editable.description.constant = constant
         return editable
     }
+
+    @available(iOSApplicationExtension 11.0, *)
+    @discardableResult
+    public func equalToSystemSpacingBelow(_ other: ConstraintItem, _ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
+        let editable = ConstraintMakerEditable(self.description)
+        editable.description.sourceLocation = (file, line)
+        editable.description.relation = .equal
+        editable.description.related = other
+        editable.description.constant = LayoutConstraint.constraints(
+            withVisualFormat: "V:[topView]-[bottomView]",
+            options: .spacingBaselineToBaseline,
+            metrics: nil,
+            views: [
+                "topView": other.target as! ConstraintView,
+                "bottomView": self.description.item as! ConstraintView,
+            ]
+        )[0].constant
+        return editable
+    }
     
     @discardableResult
     public func equalTo(_ other: ConstraintRelatableTarget, _ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {

--- a/Sources/ConstraintMakerRelatable.swift
+++ b/Sources/ConstraintMakerRelatable.swift
@@ -74,7 +74,8 @@ public class ConstraintMakerRelatable {
         return editable
     }
 
-    @available(iOSApplicationExtension 11.0, *)
+    #if os(iOS) || os(tvOS)
+    @available(iOS 11.0, tvOS 11.0, *)
     @discardableResult
     public func equalToSystemSpacingBelow(_ other: ConstraintItem, _ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
         let editable = ConstraintMakerEditable(self.description)
@@ -92,6 +93,7 @@ public class ConstraintMakerRelatable {
         )[0].constant
         return editable
     }
+    #endif
     
     @discardableResult
     public func equalTo(_ other: ConstraintRelatableTarget, _ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {

--- a/Tests/SnapKitTests/Tests.swift
+++ b/Tests/SnapKitTests/Tests.swift
@@ -145,6 +145,32 @@ class SnapKitTests: XCTestCase {
         
         XCTAssertEqual(self.container.snp_constraints.count, 6, "Should have 6 constraints installed")
     }
+
+    func testMakeSystemSpacingBelowConstraints() {
+        let v1 = View()
+        let v2 = View()
+        self.container.addSubview(v1)
+        self.container.addSubview(v2)
+
+        v1.snp.makeConstraints { (make) -> Void in
+            make.top.equalToSuperview()
+        }
+
+        XCTAssertEqual(self.container.snp_constraints.count, 1, "Should have 1 constraint installed")
+
+        v2.snp.makeConstraints { make in
+            make.firstBaseline.equalToSystemSpacingBelow(v1.snp.lastBaseline)
+        }
+
+        XCTAssertEqual(self.container.snp_constraints.count, 2, "Should have 2 constraints installed")
+
+        let constraints = self.container.snp_constraints as! [NSLayoutConstraint]
+        XCTAssertEqual(constraints[1].firstItem as! View, v2)
+        XCTAssertEqual(constraints[1].firstAttribute, NSLayoutConstraint.Attribute.firstBaseline)
+        XCTAssertEqual(constraints[1].secondItem as! View, v1)
+        XCTAssertEqual(constraints[1].secondAttribute, NSLayoutConstraint.Attribute.lastBaseline)
+        XCTAssertEqual(constraints[1].constant, 8, "Should have firstBaseline constraint with standard spacing (8)")
+    }
     
     func testUpdateConstraints() {
         let v1 = View()

--- a/Tests/SnapKitTests/Tests.swift
+++ b/Tests/SnapKitTests/Tests.swift
@@ -146,6 +146,8 @@ class SnapKitTests: XCTestCase {
         XCTAssertEqual(self.container.snp_constraints.count, 6, "Should have 6 constraints installed")
     }
 
+    #if os(iOS) || os(tvOS)
+    @available(iOS 11.0, tvOS 11.0, *)
     func testMakeSystemSpacingBelowConstraints() {
         let v1 = View()
         let v2 = View()
@@ -171,6 +173,7 @@ class SnapKitTests: XCTestCase {
         XCTAssertEqual(constraints[1].secondAttribute, NSLayoutConstraint.Attribute.lastBaseline)
         XCTAssertEqual(constraints[1].constant, 8, "Should have firstBaseline constraint with standard spacing (8)")
     }
+    #endif
     
     func testUpdateConstraints() {
         let v1 = View()


### PR DESCRIPTION
Enable creation of constraints that use standard system spacing.

Implementation of this enhancement request: https://github.com/SnapKit/SnapKit/issues/630