### PR TITLE
Update Travis to build for iPhone 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ osx_image: xcode11
 
 env:
   - ACTION=test  PLATFORM=Mac     DESTINATION='platform=macOS'
-  - ACTION=test  PLATFORM=iOS     DESTINATION='platform=iOS Simulator,name=iPhone 6S'
+  - ACTION=test  PLATFORM=iOS     DESTINATION='platform=iOS Simulator,name=iPhone 8'
   - ACTION=test  PLATFORM=tvOS    DESTINATION='platform=tvOS Simulator,name=Apple TV 4K (at 1080p)'
 
 script:


### PR DESCRIPTION
After updating to Xcode 11, the iPhone 6S simulator is no longer
available, causing all iOS builds to fail.