### PR TITLE
Use << for ConstraintAttributes options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ osx_image: xcode11
 
 env:
   - ACTION=test  PLATFORM=Mac     DESTINATION='platform=macOS'
-  - ACTION=test  PLATFORM=iOS     DESTINATION='platform=iOS Simulator,name=iPhone 6S'
+  - ACTION=test  PLATFORM=iOS     DESTINATION='platform=iOS Simulator,name=iPhone 8'
   - ACTION=test  PLATFORM=tvOS    DESTINATION='platform=tvOS Simulator,name=Apple TV 4K (at 1080p)'
 
 script:

--- a/Source/ConstraintAttributes.swift
+++ b/Source/ConstraintAttributes.swift
@@ -56,65 +56,65 @@ internal struct ConstraintAttributes : OptionSet, ExpressibleByIntegerLiteral {
     
     // normal
     
-    internal static var none: ConstraintAttributes { return 0 }
-    internal static var left: ConstraintAttributes { return 1 }
-    internal static var top: ConstraintAttributes {  return 2 }
-    internal static var right: ConstraintAttributes { return 4 }
-    internal static var bottom: ConstraintAttributes { return 8 }
-    internal static var leading: ConstraintAttributes { return 16 }
-    internal static var trailing: ConstraintAttributes { return 32 }
-    internal static var width: ConstraintAttributes { return 64 }
-    internal static var height: ConstraintAttributes { return 128 }
-    internal static var centerX: ConstraintAttributes { return 256 }
-    internal static var centerY: ConstraintAttributes { return 512 }
-    internal static var lastBaseline: ConstraintAttributes { return 1024 }
+    internal static let none: ConstraintAttributes = 0
+    internal static let left: ConstraintAttributes = ConstraintAttributes(UInt(1) << 0)
+    internal static let top: ConstraintAttributes = ConstraintAttributes(UInt(1) << 1)
+    internal static let right: ConstraintAttributes = ConstraintAttributes(UInt(1) << 2)
+    internal static let bottom: ConstraintAttributes = ConstraintAttributes(UInt(1) << 3)
+    internal static let leading: ConstraintAttributes = ConstraintAttributes(UInt(1) << 4)
+    internal static let trailing: ConstraintAttributes = ConstraintAttributes(UInt(1) << 5)
+    internal static let width: ConstraintAttributes = ConstraintAttributes(UInt(1) << 6)
+    internal static let height: ConstraintAttributes = ConstraintAttributes(UInt(1) << 7)
+    internal static let centerX: ConstraintAttributes = ConstraintAttributes(UInt(1) << 8)
+    internal static let centerY: ConstraintAttributes = ConstraintAttributes(UInt(1) << 9)
+    internal static let lastBaseline: ConstraintAttributes = ConstraintAttributes(UInt(1) << 10)
     
     @available(iOS 8.0, OSX 10.11, *)
-    internal static var firstBaseline: ConstraintAttributes { return 2048 }
-    
+    internal static let firstBaseline: ConstraintAttributes = ConstraintAttributes(UInt(1) << 11)
+
     @available(iOS 8.0, *)
-    internal static var leftMargin: ConstraintAttributes { return 4096 }
-    
+    internal static let leftMargin: ConstraintAttributes = ConstraintAttributes(UInt(1) << 12)
+
     @available(iOS 8.0, *)
-    internal static var rightMargin: ConstraintAttributes { return 8192 }
-    
+    internal static let rightMargin: ConstraintAttributes = ConstraintAttributes(UInt(1) << 13)
+
     @available(iOS 8.0, *)
-    internal static var topMargin: ConstraintAttributes { return 16384 }
-    
+    internal static let topMargin: ConstraintAttributes = ConstraintAttributes(UInt(1) << 14)
+
     @available(iOS 8.0, *)
-    internal static var bottomMargin: ConstraintAttributes { return 32768 }
-    
+    internal static let bottomMargin: ConstraintAttributes = ConstraintAttributes(UInt(1) << 15)
+
     @available(iOS 8.0, *)
-    internal static var leadingMargin: ConstraintAttributes { return 65536 }
-    
+    internal static let leadingMargin: ConstraintAttributes = ConstraintAttributes(UInt(1) << 16)
+
     @available(iOS 8.0, *)
-    internal static var trailingMargin: ConstraintAttributes { return 131072 }
-    
+    internal static let trailingMargin: ConstraintAttributes = ConstraintAttributes(UInt(1) << 17)
+
     @available(iOS 8.0, *)
-    internal static var centerXWithinMargins: ConstraintAttributes { return 262144 }
-    
+    internal static let centerXWithinMargins: ConstraintAttributes = ConstraintAttributes(UInt(1) << 18)
+
     @available(iOS 8.0, *)
-    internal static var centerYWithinMargins: ConstraintAttributes { return 524288 }
+    internal static let centerYWithinMargins: ConstraintAttributes = ConstraintAttributes(UInt(1) << 19)
     
     // aggregates
     
-    internal static var edges: ConstraintAttributes { return 15 }
-    internal static var horizontalEdges: ConstraintAttributes { return 5 }
-    internal static var verticalEdges: ConstraintAttributes { return 10 }
-    internal static var directionalEdges: ConstraintAttributes { return 58 }
-    internal static var directionalHorizontalEdges: ConstraintAttributes { return 48 }
-    internal static var directionalVerticalEdges: ConstraintAttributes { return 10 }
-    internal static var size: ConstraintAttributes { return 192 }
-    internal static var center: ConstraintAttributes { return 768 }
-    
-    @available(iOS 8.0, *)
-    internal static var margins: ConstraintAttributes { return 61440 }
-    
-    @available(iOS 8.0, *)
-    internal static var directionalMargins: ConstraintAttributes { return 245760 }
+    internal static let edges: ConstraintAttributes = [.horizontalEdges, .verticalEdges]
+    internal static let horizontalEdges: ConstraintAttributes = [.left, .right]
+    internal static let verticalEdges: ConstraintAttributes = [.top, .bottom]
+    internal static let directionalEdges: ConstraintAttributes = [.directionalHorizontalEdges, .directionalVerticalEdges]
+    internal static let directionalHorizontalEdges: ConstraintAttributes = [.leading, .trailing]
+    internal static let directionalVerticalEdges: ConstraintAttributes = [.top, .bottom]
+    internal static let size: ConstraintAttributes = [.width, .height]
+    internal static let center: ConstraintAttributes = [.centerX, .centerY]
 
     @available(iOS 8.0, *)
-    internal static var centerWithinMargins: ConstraintAttributes { return 786432 }
+    internal static let margins: ConstraintAttributes = [.leftMargin, .topMargin, .rightMargin, .bottomMargin]
+
+    @available(iOS 8.0, *)
+    internal static let directionalMargins: ConstraintAttributes = [.leadingMargin, .topMargin, .trailingMargin, .bottomMargin]
+
+    @available(iOS 8.0, *)
+    internal static let centerWithinMargins: ConstraintAttributes = [.centerXWithinMargins, .centerYWithinMargins]
     
     internal var layoutAttributes:[LayoutAttribute] {
         var attrs = [LayoutAttribute]()


### PR DESCRIPTION
Hello.
Thank you for SnapKit.
In this pull request I refactored `ConstraintAttributes`. As for me it is more clearly to use `<<` and other options to declare `OptionSet` options.
And I used `let` for all these options, it is not necessary to use `var` for them.