### PR TITLE
Make ConstraintMaker.item in public access level

### DIFF
--- a/Sources/ConstraintMaker.swift
+++ b/Sources/ConstraintMaker.swift
@@ -163,7 +163,7 @@ public class ConstraintMaker {
         return self.makeExtendableWithAttributes(.centerWithinMargins)
     }
     
-    private let item: LayoutConstraintItem
+    public let item: LayoutConstraintItem
     private var descriptions = [ConstraintDescription]()
     
     internal init(item: LayoutConstraintItem) {


### PR DESCRIPTION
The item property of ConstraintMaker is now in public access level. Developers can easily extend ConstraintMaker to add features.

There are many issues discussing about how to make aspect ratio constraint. However, because of the internal access level, developer can't create extension to extend SnapKit.

Now, we can do this:
```swift
extension ConstraintMaker {
    public func aspectRatio(_ ratio: CGSize) {
        let view = item as! ConstraintView
        self.width.equalTo(view.snp.height).multipliedBy(ratio.width / ratio.height)
    }
}
```

With this change, developer can create any helper method they like. They don't have to create issues to request this kind of features.

Related issue: #668, #417, #107, #92
Close #666  