### PR TITLE
fix SnapKitPlayground can not use SnapKit after build SnapKit.framewo…

### DIFF
--- a/SnapKit.xcodeproj/project.pbxproj
+++ b/SnapKit.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 
 /* Begin PBXFileReference section */
 		2DBA080D1F1FAD66001CFED4 /* Typealiases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typealiases.swift; sourceTree = "<group>"; };
+		39F4907D2596F81B00CDC0E3 /* SnapKitPlayground.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = SnapKitPlayground.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		3CA7D6C124592D4D005E10C2 /* ConstraintMakerRelatable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConstraintMakerRelatable+Extensions.swift"; sourceTree = "<group>"; };
 		537DCE9A1C35CD4100B5B899 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS9.1.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		7E1CB2AD227BB5520066B6C0 /* ConstraintDirectionalInsetTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstraintDirectionalInsetTarget.swift; sourceTree = "<group>"; };
@@ -118,6 +119,7 @@
 		DDC9FD8C1981B4DD009612C7 = {
 			isa = PBXGroup;
 			children = (
+				39F4907D2596F81B00CDC0E3 /* SnapKitPlayground.playground */,
 				EE6DB557251D9A6B00E0C374 /* Supporting Files */,
 				EECDB35D1AC0C95C006BBC11 /* Sources */,
 				EE94F60C1AC0F113008767FF /* Frameworks */,

--- a/SnapKit.xcworkspace/contents.xcworkspacedata
+++ b/SnapKit.xcworkspace/contents.xcworkspacedata
@@ -2,9 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:SnapKitPlayground.playground">
-   </FileRef>
-   <FileRef
       location = "container:SnapKit.xcodeproj">
    </FileRef>
 </Workspace>

--- a/SnapKitPlayground.playground/contents.xcplayground
+++ b/SnapKitPlayground.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='ios' executeOnSourceChanges='true'>
+<playground version='5.0' target-platform='ios' buildActiveScheme='true'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/SnapKitPlayground.playground/playground.xcworkspace/contents.xcworkspacedata
+++ b/SnapKitPlayground.playground/playground.xcworkspace/contents.xcworkspacedata
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-</Workspace>

--- a/SnapKitPlayground.playground/timeline.xctimeline
+++ b/SnapKitPlayground.playground/timeline.xctimeline
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Timeline
-   version = "3.0">
-   <TimelineItems>
-   </TimelineItems>
-</Timeline>


### PR DESCRIPTION
fix (#442)
I have the same problem as described in #442

I open `SnapKit.xcworkspace` not `SnapKit.xcodeproj`, and build SnapKit. and try as the README said, but it not work.
>To try SnapKit in playground, open SnapKit.xcworkspace and build SnapKit.framework for any simulator first

I read this blog [Using 3rd party frameworks in Xcode 10 Playgrounds](https://medium.com/@pardel/using-3rd-party-frameworks-in-xcode-10-playgrounds-97aa0c3f56e0) , and find that the SnapKitPlayground is not in same project. so I rebuilt a new identical file.

I just change the playground's project belong to, it seems work fine to me.

here is the playground create config, I just add the playground to `SnapKit` project.
<img width="1920" alt="create" src="https://user-images.githubusercontent.com/11785335/103146352-e3e9c100-4782-11eb-9166-9d2f9a650b54.png">

<img width="269" alt="project" src="https://user-images.githubusercontent.com/11785335/103146353-e64c1b00-4782-11eb-9979-11dd160660c5.png">

And after that the `SnapKitPlayground.playground` is under `SnapKit` project. And I found After this, the `SnapKit.xcworkspace` is no long needed. Just open `SnapKit.xcodeproj` and build framework is OK to play this playground
