### PR TITLE
Dynamic Product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,6 +34,7 @@ let package = Package(
     ],
     products: [
         .library(name: "SnapKit", targets: ["SnapKit"]),
+        .library(name: "SnapKit-Dynamic", type: .dynamic, targets: ["SnapKit"]),
     ],
     targets: [
         .target(name: "SnapKit", path: "Sources"),


### PR DESCRIPTION
This PR adds a dynamic product to SnapKit.
Having a dynamic product is important in modular project structures; multiple packages may be using SnapKit, and this allows that support without the end-user have to wrap SnapKit in their own package that exposes it and using that package in lieu of SnapKit.