### PR TITLE
Fix warning about `class`, replace it by `AnyObject`

### DIFF
--- a/Sources/LayoutConstraintItem.swift
+++ b/Sources/LayoutConstraintItem.swift
@@ -28,7 +28,7 @@
 #endif
 
 
-public protocol LayoutConstraintItem: class {
+public protocol LayoutConstraintItem: AnyObject {
 }
 
 @available(iOS 9.0, OSX 10.11, *)


### PR DESCRIPTION
Fix warning for Xcode 12.5.