### PR TITLE
Resolve Xcode 12.5 warning regarding `class` protocols

### DIFF
--- a/Sources/LayoutConstraintItem.swift
+++ b/Sources/LayoutConstraintItem.swift
@@ -28,7 +28,7 @@
 #endif
 
 
-public protocol LayoutConstraintItem: class {
+public protocol LayoutConstraintItem: AnyObject {
 }
 
 @available(iOS 9.0, OSX 10.11, *)


### PR DESCRIPTION
Resolve Xcode 12.5 warning regarding using the class keyword being deprecated in favor of AnyObject for protocol inheritance.