### PR TITLE
Fix README broken link and add missing Migration Guides section

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ SnapKit is a DSL to make Auto Layout easy on both iOS and OS X.
 - Xcode 10.0+
 - Swift 4.0+
 
+## Migration Guides
+
+- [SnapKit 3.0 Migration Guide](Documentation/SnapKit%203.0%20Migration%20Guide.md)
+
 ## Communication
 
 - If you **need help**, use [Stack Overflow](http://stackoverflow.com/questions/tagged/snapkit). (Tag 'snapkit')


### PR DESCRIPTION
**This pull request:**
- fixes the `Migration Guides` broken link by adding a missing section to the `README.md` file

**Resolved issues:** 
- #597 

**Short description:**
Currently there's a broken link in the `README.md`'s [Contents](https://github.com/SnapKit/SnapKit#contents) section - `Migration Guides` link doesn't lead anywhere since a section with that name doesn't exist. In this pull request I've added that missing `Migration Guides` section and I've listed migration guides stored in [Snapkit/Documentation/](https://github.com/SnapKit/SnapKit/tree/develop/Documentation) directory (currently it contains just one file: `SnapKit 3.0 Migration Guide.md`).